### PR TITLE
Enable dynamic RHEL 7/RHEL 8 install

### DIFF
--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -7,6 +7,12 @@
         - "{{ undercloud_hostname }}"
         - "{{ hammer_host }}"
 
+    - name: Install sshpass
+      package:
+        name: sshpass
+        state: present
+      become: true
+
     - name: clone badfish
       git:
         repo: "https://github.com/redhat-performance/badfish.git"
@@ -15,104 +21,135 @@
     - name: check python3 version
       shell: python3 --version
       register: python3_version
+      changed_when: false
       ignore_errors: true
 
     - name: Install python3
       package:
         name: python3
         state: present
-      when: python3_version.stderr != ""
+      when: python3_version.stderr | length > 0
 
     - name: Install python3 pyyaml
       pip:
         name: pyyaml
         executable: pip-3
-      become: true      
-     
+      become: true
+
     - name: install ipmitool
       package:
         name: ipmitool
         state: present
       become: true
-   
+
     - name: isntall python-netaddr
       package:
         name: "{{ item }}"
       loop:
         - python-netaddr
         - python3-netaddr
+      become: true
 
     - name: Install badfish requirements
       pip:
         requirements: "{{ ansible_user_dir }}/badfish/requirements.txt"
         executable: pip-3
       become: true
-         
+
     - name: set foreman password
       set_fact:
         chassis_password:  "{{ instackenv_content.nodes[0].pm_password }}"
 
-    - name: RHEL 8 install for OSP 15 and above 
+    - name: Check if /etc/redhat-release exists
+      stat:
+       path: /etc/redhat-release
+      register: rhel_release_stat
+      delegate_to: "{{ undercloud_hostname }}"
+
+    - name: Get RHEL version
+      become: true
+      slurp:
+        src: /etc/redhat-release
+      register: file_content
+      when: rhel_release_stat.stat.exists
+      delegate_to: "{{ undercloud_hostname }}"
+
+    - name: set version fact
+      set_fact:
+        version: "{{ file_content.content | b64decode }}"
+
+    - name: set rhel version 
+      set_fact:
+        rhel_version: "{{ version.split()[-2] }}"
+
+    - name: RHEL 8 install if needed
+      shell: hammer -u  {{ cloud_name }} -p {{ chassis_password }}  host update --name {{ undercloud_hostname }} --build 1 --operatingsystem 'RHEL 8' --overwrite 1
+      delegate_to: "{{ hammer_host }}"
+      register: rhel8_install
+      when: osp_release | int > 14 and  rhel_version is version('8.0', '<')
+
+    - name: RHEL 7 install if needed
+      shell: hammer -u {{ cloud_name }} -p {{ chassis_password }}  host update --name {{ undercloud_hostname }} --build 1 --operatingsystem 'RHEL 8' --overwrite 1
+      delegate_to: "{{ hammer_host }}"
+      register: rhel7_install
+      when: osp_release | int < 15 and  rhel_version is  version ('8.0', '>=')
+
+    - name: Reboot if OS install needed
       block:
-          - name: Set foreman RHEL 8 build
-            shell: hammer -u {{ cloud_name }} -p {{ chassis_password }}  host update --name {{ undercloud_hostname }} --build 1 --operatingsystem 'RHEL 8' --parameters overcloud=false --overwrite 1
-            delegate_to: "{{ hammer_host }}"
-          
-          - name: set undercloud to PXE boot (Supermicro)
-            shell: ipmitool -I lanplus -H mgmt-{{ undercloud_hostname }} -U quads -P {{ chassis_password }} chassis bootdev pxe options=persistent
-            when: lab_name == "scale" and undercloud_hostname.split('.')[0].split('-')[3] in scale.machine_types.supermicro
-     
-          - name: power cycle undercloud (Supermicro)
-            shell: ipmitool -I lanplus -H mgmt-{{ undercloud_hostname }} -U quads -P {{ chassis_password }} chassis power cycle 
-            when: lab_name == "scale" and undercloud_hostname.split('.')[0].split('-')[3] in scale.machine_types.supermicro
-         
-          - name: set undercloud to PXE boot off Foreman (Dell)
-            shell: ./badfish.py -H mgmt-{{ undercloud_hostname }} -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --boot-to-type foreman --pxe
-            args:
-              chdir: "{{ ansible_user_dir }}/badfish"
-            when: lab_name == "scale" and undercloud_hostname.split('.')[0].split('-')[3] in scale.machine_types.dell
 
-          - name: power cycle undercloud
-            shell: ./badfish.py -H mgmt-{{undercloud_hostname}}  -u quads -p {{ chassis_password }} --reboot-only
-            args:
-              chdir: "{{ ansible_user_dir }}/badfish"
-            when: lab_name == "scale" and undercloud_hostname.split('.')[0].split('-')[3] in scale.machine_types.dell
+        - name: set undercloud to PXE boot (Supermicro)
+          shell: ipmitool -I lanplus -H mgmt-{{ undercloud_hostname }} -U quads -P {{ chassis_password }} chassis bootdev pxe options=persistent
+          when: lab_name == "scale" and undercloud_hostname.split('.')[0].split('-')[3] in scale.machine_types.supermicro
 
-          - name: wait for 420 seconds before checking for undercloud
-            wait_for:
-                timeout: 420
+        - name: power cycle undercloud (Supermicro)
+          shell: ipmitool -I lanplus -H mgmt-{{ undercloud_hostname }} -U quads -P {{ chassis_password }} chassis power cycle
+          when: lab_name == "scale" and undercloud_hostname.split('.')[0].split('-')[3] in scale.machine_types.supermicro
 
-          - name: waiting for the undercloud to be available
-            wait_for:
-              port: 22
-              host: "{{ hostvars['localhost']['undercloud_hostname'] }}"
-              search_regex: OpenSSH
-              timeout: 30
-            register: uc_reachable
-            delegate_to: localhost
-            retries: 100
-            until: uc_reachable|succeeded
+        - name: set undercloud to PXE boot off Foreman (Dell)
+          shell: ./badfish.py -H mgmt-{{ undercloud_hostname }} -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --boot-to-type foreman --pxe
+          args:
+            chdir: "{{ ansible_user_dir }}/badfish"
+          when: lab_name == "scale" and undercloud_hostname.split('.')[0].split('-')[3] in scale.machine_types.dell
 
-          - name: add keys to new undercloud
-            include_tasks: tasks/copykeys.yml
-            vars:
-              hostname: "{{ undercloud_hostname }}"
+        - name: power cycle undercloud
+          shell: ./badfish.py -H mgmt-{{ undercloud_hostname }}  -u quads -p {{ chassis_password }} --reboot-only
+          args:
+            chdir: "{{ ansible_user_dir }}/badfish"
+          when: lab_name == "scale" and undercloud_hostname.split('.')[0].split('-')[3] in scale.machine_types.dell
 
-          - name: add undercloud_host to inventory file
-            add_host:
-             name: "{{ undercloud_hostname }}"
-             groups: "baremetal,undercloud,tester"
-             ansible_host: "{{ undercloud_hostname }}"
-             ansible_user: "{{ ansible_ssh_user }}"
-             ansible_ssh_private_key_file: "{{ ansible_ssh_key }}"
-             ansible_python_interpreter: /usr/libexec/platform-python
+        - name: wait for 420 seconds before checking for undercloud
+          wait_for:
+            timeout: 420
 
-      when: osp_release|int > 14
+        - name: waiting for the undercloud to be available
+          wait_for:
+            port: 22
+            host: "{{ hostvars['localhost']['undercloud_hostname'] }}"
+            search_regex: OpenSSH
+            timeout: 30
+          register: uc_reachable
+          delegate_to: localhost
+          retries: 100
+          until: uc_reachable|succeeded
 
+        - name: add keys to new undercloud
+          include_tasks: tasks/copykeys.yml
+          vars:
+            hostname: "{{ undercloud_hostname }}"
+      when: rhel7_install is not skipped or rhel8_install is not skipped
+
+    - name: add undercloud_host to inventory file
+      add_host:
+        name: "{{ undercloud_hostname }}"
+        groups: "baremetal,undercloud,tester"
+        ansible_host: "{{ undercloud_hostname }}"
+        ansible_user: "{{ ansible_ssh_user }}"
+        ansible_ssh_private_key_file: "{{ ansible_ssh_key }}"
+        ansible_python_interpreter: /usr/libexec/platform-python
+      when: rhel8_install is not skipped
 
 - hosts: undercloud
-  tasks: 
-      
+  tasks:
       - name: Install repos on undercloud
         shell: |
           ./clean-interfaces.sh --nuke
@@ -122,6 +159,7 @@
           yum update -y
         args:
           chdir: "{{ ansible_user_dir }}"
+        changed_when: false
 
       - name: Ensure SELinux is set to enforcing mode
         selinux:
@@ -132,6 +170,7 @@
         shell: "nohup sh -c '( sleep 5 ; shutdown -r now )' &"
         async: 0
         poll: 0
+        changed_when: false
         ignore_errors: true
 
       - name: wait for undercloud to go down
@@ -141,6 +180,7 @@
         retries: 100
         delay: 3
         ignore_errors: true
+        changed_when: false
         delegate_to: localhost
 
       - name: wait for 180 seconds before checking for undercloud

--- a/tasks/prepare_inventory.yml
+++ b/tasks/prepare_inventory.yml
@@ -1,10 +1,26 @@
----      
+---
 - name: add localhost to inventory file
   add_host:
-      name: "localhost"
-      groups: "local"
-      ansible_connection: "local"
+    name: "localhost"
+    groups: "local"
+    ansible_connection: "local"
 
+- name: Ping undercloud and set python version for RHEL 8
+  ping:
+  register: ping_output
+  delegate_to: "{{ undercloud_hostname }}"
+  ignore_errors: true
+
+- name: Add undercloud_host after setting python interpereter (RHEL 8)
+  add_host:
+    name: "{{ undercloud_hostname }}"
+    groups: "baremetal,undercloud,tester"
+    ansible_host: "{{ undercloud_hostname }}"
+    ansible_user: "{{ ansible_ssh_user }}"
+    ansible_ssh_private_key_file: "{{ ansible_ssh_key }}"
+    ansible_python_interpreter: /usr/libexec/platform-python
+  when: "'interpreter' in ping_output.msg"
+ 
 - name: add undercloud_host to inventory file
   add_host:
       name: "{{ undercloud_hostname }}"
@@ -12,15 +28,17 @@
       ansible_host: "{{ undercloud_hostname }}"
       ansible_user: "{{ ansible_ssh_user }}"
       ansible_ssh_private_key_file: "{{ ansible_ssh_key }}"
+  when: ping_output.rc == 0
 
-- block:
-      - name: generate inventory file
-        template:
-            dest: "{{ infrared_hosts_dir }}/{{ inventory_file_name }}"
-            src: inventory.j2
-      - name: update inventory file symlink
-        file:
-            dest: "{{ infrared_hosts_file }}"
-            state: link
-            src: "{{ inventory_file_name }}"
+- name: Generate inventory file
+  block:
+    - name: generate inventory file
+      template:
+        dest: "{{ infrared_hosts_dir }}/{{ inventory_file_name }}"
+        src: inventory.j2
+    - name: update inventory file symlink
+      file:
+        dest: "{{ infrared_hosts_file }}"
+        state: link
+        src: "{{ inventory_file_name }}"
   when: hosts_file_exist is not defined


### PR DESCRIPTION
Correct version of RHEL depending on OSP release is automatically installed.
Eariler only RHEL 8 isntall was supported. Also now, the foreman install only
happends if there isa  mismatch between existing version of RHEL on the UC host
and what is required by the OSP release.