### PR TITLE
Set clean_nodes to true

### DIFF
--- a/undercloud.yml
+++ b/undercloud.yml
@@ -3,7 +3,15 @@
       - name: run tripleo-undercloud
         shell: |
           source {{ infrared_dir }}/.venv/bin/activate
-          infrared tripleo-undercloud -vv --version {{ osp_release }} --images-task rpm --config-options DEFAULT.local_interface={{ ctlplane_interface }} --config-options ctlplane-subnet.cidr={{ cidr }} --config-options ctlplane-subnet.gateway={{ gateway }} --config-options ctlplane-subnet.dhcp_start={{ dhcp_start }} --config-options ctlplane-subnet.dhcp_end={{ dhcp_end }} --config-options ctlplane-subnet.inspection_iprange={{ inspection_iprange }} &> undercloud_install.log
+          infrared tripleo-undercloud -vv \
+          --version {{ osp_release }} \
+          --images-task rpm \
+          --config-options DEFAULT.local_interface={{ ctlplane_interface }} \
+          --config-options DEFAULT.clean_nodes=true \
+          --config-options ctlplane-subnet.cidr={{ cidr }} \
+          --config-options ctlplane-subnet.gateway={{ gateway }} \
+          --config-options ctlplane-subnet.dhcp_start={{ dhcp_start }} \
+          --config-options ctlplane-subnet.dhcp_end={{ dhcp_end }} --config-options ctlplane-subnet.inspection_iprange={{ inspection_iprange }} &> undercloud_install.log
         args:
             chdir: "{{ infrared_dir }}"
         changed_when: false


### PR DESCRIPTION
Set clean_nodes to true in undercloud.conf.
Aslo make the infrared deploy command a bit more readable.

Signed-off-by: Charles Short <chucks@redhat.com>