### PR TITLE
Change group_vars cloud name defaults

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -3,7 +3,7 @@ infrared_dir: "{{ ansible_user_dir }}/infrared"
 infrared_workspaces_dir: "{{ ansible_user_dir }}/.infrared/.workspaces"
 infrared_hosts_file: "{{ infrared_workspaces_dir }}/active/hosts"
 instackenv_file: "{{ ansible_user_dir }}/instackenv.json"
-cloud_name: cloud27
+cloud_name: cloud00
 lab_name: scale
 ansible_ssh_user: root
 ansible_ssh_pass: password


### PR DESCRIPTION
Setting it by default to a non-existent cloud to minimize accidents.