### PR TITLE
Fix package install on fedora30

### DIFF
--- a/tasks/setup_infrared.yml
+++ b/tasks/setup_infrared.yml
@@ -9,7 +9,7 @@
       - libffi-devel
       - python-virtualenv
       - libselinux-python
-      - python30-virtualenv
+      - python3-virtualenv
       - python3-libselinux
   become: true
   failed_when: false

--- a/tasks/setup_infrared.yml
+++ b/tasks/setup_infrared.yml
@@ -9,7 +9,10 @@
       - libffi-devel
       - python-virtualenv
       - libselinux-python
+      - python30-virtualenv
+      - python3-libselinux
   become: true
+  failed_when: false
 
 - name: clone infrared
   git:


### PR DESCRIPTION
python-virtualenv and libselinux-python doesnt exist on f30,
Add python3-virtualenv and python3-libselinux which do.

Signed-off-by: Charles Short <chucks@redhat.com>