### PR TITLE
external network access from undercloud

### DIFF
--- a/files/virt/network/three-nics-vlans/compute.yaml.j2
+++ b/files/virt/network/three-nics-vlans/compute.yaml.j2
@@ -180,7 +180,7 @@ resources:
                           members:
                             -
                               type: interface
-                              name: nic1
+                              name: ctlplane_interface
                               primary: true
                           use_dhcp: false
                           addresses:

--- a/files/virt/network/three-nics-vlans/controller.yaml.j2
+++ b/files/virt/network/three-nics-vlans/controller.yaml.j2
@@ -192,7 +192,7 @@ resources:
                           members:
                             -
                               type: interface
-                              name: nic1
+                              name: ctlplane_interface
                               primary: true
                             -
                               type: vlan

--- a/files/virt/network/three-nics-vlans/legacy/compute.yaml.j2
+++ b/files/virt/network/three-nics-vlans/legacy/compute.yaml.j2
@@ -70,7 +70,7 @@ resources:
           network_config:
                         -
                           type: interface
-                          name: nic1
+                          name: ctlplane_interface
                           use_dhcp: false
                           addresses:
                             -

--- a/files/virt/network/three-nics-vlans/legacy/controller.yaml.j2
+++ b/files/virt/network/three-nics-vlans/legacy/controller.yaml.j2
@@ -85,7 +85,7 @@ resources:
                           name: br-ex
                           members:
                           - type: interface
-                            name: nic1
+                            name: ctlplane_interface
                             primary: true
                             -
                               type: vlan

--- a/files/virt_4nics/network/four-nics-vlans/compute.yaml.j2
+++ b/files/virt_4nics/network/four-nics-vlans/compute.yaml.j2
@@ -180,7 +180,7 @@ resources:
                           members:
                             -
                               type: interface
-                              name: nic1
+                              name: ctlplane_interface
                               primary: true
                           use_dhcp: false
                           addresses:

--- a/files/virt_4nics/network/four-nics-vlans/controller.yaml.j2
+++ b/files/virt_4nics/network/four-nics-vlans/controller.yaml.j2
@@ -192,7 +192,7 @@ resources:
                           members:
                             -
                               type: interface
-                              name: nic1
+                              name: ctlplane_interface
                               primary: true
                           use_dhcp: false
                           addresses:
@@ -264,7 +264,7 @@ resources:
                           members:
                             -
                               type: interface
-                              name: nic4
+                              name: external_interface
                               primary: true
                             -
                               type: vlan

--- a/files/virt_4nics/network/four-nics-vlans/legacy/compute.yaml.j2
+++ b/files/virt_4nics/network/four-nics-vlans/legacy/compute.yaml.j2
@@ -70,7 +70,7 @@ resources:
           network_config:
                         -
                           type: interface
-                          name: nic1
+                          name: ctlplane_interface
                           use_dhcp: false
                           addresses:
                             -

--- a/files/virt_4nics/network/four-nics-vlans/legacy/controller.yaml.j2
+++ b/files/virt_4nics/network/four-nics-vlans/legacy/controller.yaml.j2
@@ -85,7 +85,7 @@ resources:
                           name: br-ctlplance
                           members:
                           - type: interface
-                            name: nic1
+                            name: ctlplane_interface
                             primary: true
                           use_dhcp: false
                           addresses:
@@ -147,7 +147,7 @@ resources:
                           use_dhcp: false
                           members:
                           - type: interface
-                            name: nic4
+                            name: external_interface
                             primary: true
                             -
                               type: vlan

--- a/get_interfaces.yml
+++ b/get_interfaces.yml
@@ -104,6 +104,18 @@
           ctlplane_interface: "{{ hostvars[undercloud_host]['ctlplane_interface'] }}"
           nic_configs: "{{ ansible_user_dir }}/{{ virt }}"
 
+      - name: remove ctlplane interface from eligible interfaces
+        set_fact:
+          ifaces: "{{ ifaces | difference([ctlplane_interface]) }}"
+
+      - name: get external network interface
+        set_fact:
+            external_interface: "{{ (virt == 'virt_4nics') | ternary(ifaces[0], ctlplane_interface) }}"
+
+      - name: remove external interface from  eligible interfaces
+        set_fact:
+          ifaces: "{{ ifaces | difference([external_interface]) }}"
+
       - name: Ensure deployment folder nested structure exists
         copy:
             src: "{{ virt }}"
@@ -131,14 +143,18 @@
       - name: replace control plance interface
         replace:
             path: "{{ item.src }}"
-            regexp: "nic1"
+            regexp: "ctlplane_interface"
             replace: "{{ ctlplane_interface }}"
         with_filetree: '{{ nic_configs }}'
         when: item.state == 'file'
 
-      - name: set eligible interfaces
-        set_fact:
-          ifaces: "{{ ifaces | difference([ctlplane_interface]) }}"
+      - name: replace External network interface
+        replace:
+            path: "{{ item.src }}"
+            regexp: "external_interface"
+            replace: "{{ external_interface }}"
+        with_filetree: '{{ nic_configs }}'
+        when: item.state == 'file'
 
       - name: Replace other nic names with interface names
         include_tasks: tasks/replace_nic_names.yml

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -43,4 +43,10 @@ gateway: 192.168.24.1
 dhcp_start: 192.168.24.5
 dhcp_end: 192.168.24.105
 inspection_iprange: 192.168.24.110,192.168.24.250
+# external network params for adding add external network to
+# undercloud to access overcloud resources
+external_gateway: 10.0.0.1/16
+external_network_broadcast: 10.0.255.255
+external_network_vlan_id: 10
+ 
 

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -72,3 +72,13 @@
         args:
             chdir: "{{ infrared_dir }}"
         when: ( extra_templates is defined and extra_templates|length>0 ) or ( parameter_defaults is defined and parameter_defaults|length>0 )
+
+      - name: create vlan interface on external interface
+        vars:
+            vlan_interface: "{{ external_interface }}.{{ external_network_vlan_id }}"
+        shell: |
+            ip link add link {{ external_interface }} name {{ vlan_interface }} type vlan id {{ external_network_vlan_id }}
+            ip link set dev {{ vlan_interface }} up
+            ip a a {{ external_gateway }} brd {{ external_network_broadcast }} dev {{ vlan_interface }}
+        delegate_to: "{{ undercloud_hostname }}"
+        become: true


### PR DESCRIPTION
external network access from undrecloud is needed to access
overcloud resources. We need to identify physical interface
which we added to br-ex in controller nodes.

We follow this strategy
1) When controller has seperate nic for external network,
we use the last available interface for external network.
four-nics-vlans config files use this approach.
2) When external network and control plane network share
the same physical nic, we use control plane interface as
external network interface.
three-nics-vlans use this approach.
After deploying overcloud we create a vlan interface on
this external interface and assign ip address to it.