### PR TITLE
Use template to configure undercloud.conf

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -24,3 +24,7 @@
         file:
             path: "{{ ansible_user_dir }}/virt_4nics"
             state: absent
+      - name: Remove undercloud.conf
+        file:
+            path: "{{ ansible_user_dir }}/undercloud.conf"
+            state: absent

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -3,6 +3,7 @@ infrared_dir: "{{ ansible_user_dir }}/infrared"
 infrared_workspaces_dir: "{{ ansible_user_dir }}/.infrared/.workspaces"
 infrared_hosts_file: "{{ infrared_workspaces_dir }}/active/hosts"
 instackenv_file: "{{ ansible_user_dir }}/instackenv.json"
+undercloud_conf: "{{ ansible_user_dir }}/undercloud.conf"
 cloud_name: cloud00
 lab_name: scale
 ansible_ssh_user: root
@@ -48,5 +49,4 @@ inspection_iprange: 192.168.24.110,192.168.24.250
 external_gateway: 10.0.0.1/16
 external_network_broadcast: 10.0.255.255
 external_network_vlan_id: 10
- 
-
+clean_debug: False

--- a/templates/undercloud.conf.j2
+++ b/templates/undercloud.conf.j2
@@ -1,0 +1,19 @@
+[DEFAULT]
+local_interface = {{ ctlplane_interface }}
+local_ip = {{ gateway }}/{{ subnet_mask }}
+undercloud_ntp_servers = clock.redhat.com,clock2.redhat.com
+{% if clean_debug %}
+clean_nodes = True
+{% endif %}
+
+{% if osp_release <= 12 %}
+network_cidr = {{ cidr }}
+network_gateway = {{ gateway }}
+{% else %}
+[ctlplane-subnet]
+cidr = {{ cidr }}
+gateway = {{ gateway }}
+{% endif %}
+dhcp_start = {{ dhcp_start }}
+dhcp_end = {{ dhcp_end }}
+inspection_iprange = {{ inspection_iprange }}

--- a/undercloud.yml
+++ b/undercloud.yml
@@ -1,5 +1,10 @@
 - hosts: localhost
   tasks:
+      - name: Setup undercloud.conf
+        template:
+            src: undercloud.conf.j2
+            dest: "{{ undercloud_conf }}"
+
       - name: run tripleo-undercloud
         shell: |
           source {{ infrared_dir }}/.venv/bin/activate
@@ -7,12 +12,7 @@
           --version {{ osp_release }} \
           --build {{ osp_puddle }} \
           --images-task rpm \
-          --config-options DEFAULT.local_interface={{ ctlplane_interface }} \
-          --config-options DEFAULT.clean_nodes=true \
-          --config-options ctlplane-subnet.cidr={{ cidr }} \
-          --config-options ctlplane-subnet.gateway={{ gateway }} \
-          --config-options ctlplane-subnet.dhcp_start={{ dhcp_start }} \
-          --config-options ctlplane-subnet.dhcp_end={{ dhcp_end }} --config-options ctlplane-subnet.inspection_iprange={{ inspection_iprange }} &> undercloud_install.log
+          --config-file {{ undercloud_conf }} &> undercloud_install.log
         args:
             chdir: "{{ infrared_dir }}"
         changed_when: false


### PR DESCRIPTION
Rather than using the CLI to configure the undercloud.conf
use a template.

Signed-off-by: Charles Short <chucks@redhat.com>