### PR TITLE
change undercloud_instackenv to overcloud_instackenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ chmod 0440 /etc/sudoers.d/username
 
 Below are the sequence of steps these playbooks run before deploying overcloud
 1) Clone and setup infrared environment
-2) Download instackenv file from scalelab (playbboks assume that undercloud is the first node in this instackenv file)
+2) Download instackenv file from scalelab (playbooks assume that undercloud is the first node in this instackenv file)
 3) Prepare internal variables from this file i.e
    undercloud_host: first node in instackenv
    ctlplane_interface: will get the interface name from the mac provided in instackenv
@@ -34,8 +34,8 @@ Below are the sequence of steps these playbooks run before deploying overcloud
    We use 'virt' if we have 3 eligible free interfaces ( prepared from stemp 4)
    or 'virt_4nics' if more than 3 interfaces.
    Interface names in these default template files are replaced with physical nic names which we got from step 4 above.
-6) Prepare undercloud_instackenv.json which will be used for tripleo undercloud install from instackenv file download from the scalelab.
-   Tasks will remove undercloud node from the download file and generate new undercloud_instackenv.json file.
+6) Prepare overcloud_instackenv.json which will be used for describing overcloud baremetal nodes from instackenv file downloaded  from the scalelab.
+   Tasks will remove undercloud node from the downloaded instackenv file and generate new overcloud_instackenv.json file.
 7) Run infrared plugins
    a) undercloud to install the undercloud
    b) overcloud plugin to install overcloud

--- a/browbeat.yml
+++ b/browbeat.yml
@@ -26,7 +26,7 @@
     - name: generate hosts file
       shell: |
           source /home/stack/stackrc
-          ./generate_tripleo_hostfile.sh -l 
+          ./generate_tripleo_hostfile.sh -l
       args:
           chdir: "{{ browbeat_dir }}/ansible"
     - name: install browbeat

--- a/cleanup.yml
+++ b/cleanup.yml
@@ -12,9 +12,9 @@
         file:
             path: "{{ instackenv_file }}"
             state: absent
-      - name: remove undercloud_instackenv.json
+      - name: remove overcloud_instackenv.json
         file:
-            path: "~/undercloud_instackenv.json"
+            path: "~/overcloud_instackenv.json"
             state: absent
       - name: remove nic-configs virt
         file:

--- a/intropsect.yml
+++ b/intropsect.yml
@@ -8,7 +8,7 @@
       - name: run tripleo-overcloud introspection
         shell: |
             source .venv/bin/activate
-            infrared tripleo-overcloud -vvv --version {{ osp_release }} --build {{ osp_puddle }} --instackenv-file {{ undercloud_instackenv_path }} --deployment-files {{ nic_configs }} --introspect yes &> overcloud_introspect.log
+            infrared tripleo-overcloud -vvv --version {{ osp_release }} --build {{ osp_puddle }} --instackenv-file {{ overcloud_instackenv_path }} --deployment-files {{ nic_configs }} --introspect yes &> overcloud_introspect.log
         args:
             chdir: "{{ infrared_dir }}"
         changed_when: false

--- a/tag.yml
+++ b/tag.yml
@@ -6,7 +6,7 @@
             ansible_user: "stack"
       - name: copy instack file to /home/stack/instackenv.json for infrared tagging
         copy:
-            src: "{{ undercloud_instackenv_path }}"
+            src: "{{ overcloud_instackenv_path }}"
             dest: "/home/stack/instackenv.json"
         delegate_to: "{{ groups.undercloud|first }}"
 

--- a/tasks/load_instackenv.yml
+++ b/tasks/load_instackenv.yml
@@ -23,19 +23,19 @@
   set_fact:
     instackenv_content: "{{ instackenv_content }}"
     undercloud_hostname: "{{ undercloud_hostname|default(instackenv_content.nodes[0].pm_addr | replace('mgmt-','') | replace('-drac', '')) }}"
-    undercloud_instackenv_path: "~/undercloud_instackenv.json"
+    overcloud_instackenv_path: "~/overcloud_instackenv.json"
   vars:
       instackenv_content: "{{ lookup('file', '{{ instackenv_file }}') | from_json }}"
 
-- name: set undercloud_instackenv content
+- name: set overcloud_instackenv content
   set_fact:
       instackenv_content: |
           {% set a=instackenv_content.pop('nodes') %}
           {{ instackenv_content | combine({'nodes': a|difference([a[0]])}, recursive=True) }}
 
-- name: create undercloud_instackenv.json file
+- name: create overcloud_instackenv.json file
   copy:
-      dest: "{{ undercloud_instackenv_path }}"
+      dest: "{{ overcloud_instackenv_path }}"
       content: "{{ instackenv_content }}"
 
 - name: replace instackenv_content with original data


### PR DESCRIPTION
This naming convention will help in identifying that the undercloud node is excluded from the instackenv.json file and new file  overcloud_instackenv.json is created.