### PR TITLE
undercloud container params

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -38,6 +38,10 @@ scale:
       - r630
       - r730xd
       - r930
+# containers params
+registry_mirror: redhat.com
+registry_namespace: redhat
+insecure_registries: redhat.com
 # undercloud.conf ctlplane-subnet section config options
 cidr: 192.168.24.0/24
 gateway: 192.168.24.1

--- a/templates/undercloud.conf.j2
+++ b/templates/undercloud.conf.j2
@@ -5,6 +5,11 @@ undercloud_ntp_servers = clock.redhat.com,clock2.redhat.com
 {% if clean_debug %}
 clean_nodes = True
 {% endif %}
+{% if osp_release > 13 %}
+container_images_file=/home/stack/containers-prepare-parameter.yaml
+container_insecure_registries={{ registry_mirror }},{{ insecure_registries }}
+undercloud_timezone = UTC
+{% endif %}
 
 {% if osp_release <= 12 %}
 network_cidr = {{ cidr }}

--- a/undercloud.yml
+++ b/undercloud.yml
@@ -1,10 +1,15 @@
 - hosts: localhost
+  vars:
+    container_params: ""
   tasks:
       - name: Setup undercloud.conf
         template:
             src: undercloud.conf.j2
             dest: "{{ undercloud_conf }}"
-
+      - name: Set container params
+        set_fact:
+          container_params: "--registry-mirror {{ registry_mirror }} --registry-namespace {{ registry_namespace }}"
+        when: osp_release > 13
       - name: run tripleo-undercloud
         shell: |
           source {{ infrared_dir }}/.venv/bin/activate
@@ -12,7 +17,7 @@
           --version {{ osp_release }} \
           --build {{ osp_puddle }} \
           --images-task rpm \
-          --config-file {{ undercloud_conf }} &> undercloud_install.log
+          --config-file {{ undercloud_conf }} {{ container_params }} &> undercloud_install.log
         args:
             chdir: "{{ infrared_dir }}"
         changed_when: false


### PR DESCRIPTION
OSP14 and above uses containers for undercloud.
We need to pass valid registries for container
prepare param.