### PR TITLE
use python interpreter with delegate_to

### DIFF
--- a/overcloud.yml
+++ b/overcloud.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  gather_facts: yes
   vars:
       instackenv_content: "{{ lookup('file', '{{ instackenv_file }}') | from_json }}"
   tasks:
@@ -15,6 +16,8 @@
             register: env_files
             loop: "{{ extra_templates }}"
             delegate_to: "{{ undercloud_hostname }}"
+            vars:
+              ansible_python_interpreter: "{{ python_interpreter }}"
 
           - name: Copy files to undercloud if they do not exist
             copy:
@@ -40,6 +43,8 @@
         register: nodes_uuids
         changed_when: false
         delegate_to: "{{ groups.undercloud|first }}"
+        vars:
+          ansible_python_interpreter: "{{ python_interpreter }}"
 
       - name: check registered nodes with requested node count
         debug:
@@ -76,6 +81,7 @@
       - name: create vlan interface on external interface
         vars:
             vlan_interface: "{{ external_interface }}.{{ external_network_vlan_id }}"
+            ansible_python_interpreter: "{{ python_interpreter }}"
         shell: |
             ip link add link {{ external_interface }} name {{ vlan_interface }} type vlan id {{ external_network_vlan_id }}
             ip link set dev {{ external_interface }} up
@@ -85,6 +91,8 @@
         become: true
 
       - name: masquerade on public interface
+        vars:
+            ansible_python_interpreter: "{{ python_interpreter }}"
         shell: |
             iptables -t nat -A POSTROUTING -o {{ public_interface }} -j MASQUERADE
         delegate_to: "{{ undercloud_hostname }}"

--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -1,4 +1,5 @@
 - hosts: localhost
+  gather_facts: yes
   vars:
       badfish_venv: "{{ ansible_user_dir }}/badfish/.venv"
   tasks:
@@ -28,6 +29,8 @@
        path: /etc/redhat-release
       register: rhel_release_stat
       delegate_to: "{{ undercloud_hostname }}"
+      vars:
+        ansible_python_interpreter: "{{ python_interpreter }}"
 
     - name: Get RHEL version
       become: true
@@ -36,6 +39,8 @@
       register: file_content
       when: rhel_release_stat.stat.exists
       delegate_to: "{{ undercloud_hostname }}"
+      vars:
+        ansible_python_interpreter: "{{ python_interpreter }}"
 
     - name: set version fact
       set_fact:
@@ -111,6 +116,7 @@
       when: rhel7_install is not skipped or rhel8_install is not skipped
 
 - hosts: undercloud
+  gather_facts: yes
   tasks:
       - name: Install repos on undercloud
         shell: |

--- a/tag.yml
+++ b/tag.yml
@@ -1,4 +1,5 @@
 - hosts: localhost
+  gather_facts: yes
   tasks:
       - name: add undercloud_host to inventory file
         add_host:
@@ -9,6 +10,8 @@
             src: "{{ overcloud_instackenv_path }}"
             dest: "/home/stack/instackenv.json"
         delegate_to: "{{ groups.undercloud|first }}"
+        vars:
+            ansible_python_interpreter: "{{ python_interpreter }}"
 
       - name: run tripleo-overcloud tagging
         shell: |


### PR DESCRIPTION
"delegate_to" needs ansible_python_interpretor to use
correct python interpreter on remote host.

Fixes: #88