### PR TITLE
Use is var is succeeded instead of var|succeeded

### DIFF
--- a/prepare_undercloud.yml
+++ b/prepare_undercloud.yml
@@ -70,7 +70,7 @@
       register: uc_reachable
       delegate_to: localhost
       retries: 100
-      until: uc_reachable|succeeded
+      until: uc_reachable is succeeded
 
     - name: add stack user
       user:

--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -107,7 +107,7 @@
           register: uc_reachable
           delegate_to: localhost
           retries: 100
-          until: uc_reachable|succeeded
+          until: uc_reachable is succeeded
       when: (os_install is defined) and (os_install != false)
 
     - name: Check if stack user exists


### PR DESCRIPTION
This will be deprecated in ansible 2.9