### PR TITLE
Set timeout for introspection

### DIFF
--- a/intropsect.yml
+++ b/intropsect.yml
@@ -8,6 +8,8 @@
         args:
             chdir: "{{ infrared_dir }}"
         changed_when: false
+        async: 2400
+        poll: 60
         ignore_errors: true
 
 - hosts: undercloud


### PR DESCRIPTION
Without this if a node does not introspect, jetpack is stuck at overcloud node instrospection until SSH timeout.