### PR TITLE
set master_doc

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+master_doc = 'index'
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Need to set this to master_doc = 'index' to specify the document that contains the root toctree directive.
