### PR TITLE
Increase external network range

### DIFF
--- a/external.yml
+++ b/external.yml
@@ -37,7 +37,7 @@
             ip link add link {{ ext_iface }} name {{ vlan_interface }} type vlan id {{ external_network_vlan_id }}
             ip link set dev {{ ext_iface }} up
             ip link set dev {{ vlan_interface }} up
-            ip a a {{ external_gateway }} brd {{ external_network_broadcast }} dev {{ vlan_interface }}
+            ip a a {{ external_gateway }} dev {{ vlan_interface }}
         become: true
         ignore_errors: true
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -83,7 +83,7 @@ inspection_iprange: 192.168.24.110,192.168.24.250
 # undercloud to access overcloud resources
 external_gateway: 172.18.0.1/16
 external_network_vlan_id: 300
-clean_debug: True
+clean_debug: False
 #adding changes 
 external_net_cidr: 172.18.0.0/16
 external_allocation_pools_start: 172.18.0.50

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -81,15 +81,14 @@ dhcp_end: 192.168.24.105
 inspection_iprange: 192.168.24.110,192.168.24.250
 # external network params for adding external network to
 # undercloud to access overcloud resources
-external_gateway: 172.17.5.1/24
-external_network_broadcast: 172.17.5.255
+external_gateway: 172.18.0.1/16
 external_network_vlan_id: 300
-clean_debug: False
+clean_debug: True
 #adding changes 
-external_net_cidr: 172.17.5.0/24
-external_allocation_pools_start: 172.17.5.50
-external_allocation_pools_end: 172.17.5.150
-external_interface_default_route: 172.17.5.1
+external_net_cidr: 172.18.0.0/16
+external_allocation_pools_start: 172.18.0.50
+external_allocation_pools_end: 172.18.0.150
+external_interface_default_route: 172.18.0.1
 #internal
 internal_api_net_cidr: 172.17.1.0/24
 internal_api_allocation_pools_start: 172.17.1.10


### PR DESCRIPTION
We use the same CIDR(172.17.5.0/24) for floating ip in overcloud VMs.
But this won't be sufficient for scale testing. So use bigger
external network range.

Also set clean_debug to true by default, as most of the time
we will be deleting undercloud and redeploying.