### PR TITLE
remove alias interface names

### DIFF
--- a/external.yml
+++ b/external.yml
@@ -5,24 +5,9 @@
   vars:
        external_interface: "{{ hostvars['localhost']['external_interface'] }}"
   tasks:
-      - name: set ext_interface for baremetal
-        block:
-          - name: get ext_interface
-            shell: |
-              for i in /sys/class/net/*
-              do
-                udevcontent=`udevadm info -p $i --query property`
-                if [[ $udevcontent =~ {{ external_interface }} ]]
-                then
-                  ext_interface=`echo $i | cut -d '/' -f 5`
-                  break
-                fi
-              done
-              echo $ext_interface
-            register: ext_interface
-          - name: set ext_iface
-            set_fact:
-              ext_iface: "{{ ext_interface.stdout }}"
+      - name: set ext_iface
+        set_fact:
+          ext_iface: "{{ external_interface }}"
         when: virtual_uc != true
 
       - name: set ext_iface

--- a/undercloud.yml
+++ b/undercloud.yml
@@ -2,30 +2,9 @@
   vars:
     container_params: ""
   tasks:
-      - name: set undercloud local interface
-        block:
-          - name: get undercloud_local_interface
-            shell: |
-              for i in /sys/class/net/*
-              do
-                udevcontent=`udevadm info -p $i --query property`
-                if [[ $udevcontent =~ {{ ctlplane_interface }} ]]
-                then
-                  undercloud_local_interface=`echo $i | cut -d '/' -f 5`
-                  break
-                fi
-              done
-              echo $undercloud_local_interface
-            register: local_interface
-            delegate_to: "{{ undercloud_hostname }}"
-            vars:
-              ansible_python_interpreter: "{{ python_interpreter }}"
-              ansible_user: "stack"
-            become: true
-
-          - name: set undercloud_local_interface
-            set_fact:
-              undercloud_local_interface: "{{ local_interface.stdout }}"
+      - name: set undercloud_local_interface
+        set_fact:
+          undercloud_local_interface: "{{ ctlplane_interface }}"
         when: virtual_uc != true
 
       - name: set undercloud_local_interface


### PR DESCRIPTION
We were using udevadm on sys interfaces to get device
net name path for os-net-mappings.
As we removed os-net-mappings, we shouldn't use udevadm
and instead directly use the control and external interface
names.