### PR TITLE
revert 1821dc96a3736eecd424194c2873966cf39183fa

### DIFF
--- a/tasks/delete_introspection_failed_nodes.yml
+++ b/tasks/delete_introspection_failed_nodes.yml
@@ -44,14 +44,12 @@
   register: total_nodes
   changed_when: false
 
-- name: wait for all nodes to be available
+- name: set provision state of all nodes to available
   shell: |
-    source ~/stackrc;
-    openstack baremetal node show {{ item }} -c provision_state -f value
-  register: status
-  until: ('available' in status.stdout)
-  delay: 10
-  retries: 720
-  ignore_errors: true
-  changed_when: False
+      source ~/stackrc;
+      export PROV_STATE=$(openstack baremetal node show {{ item }} -c provision_state -f value);
+      if [[ $PROV_STATE != *"available"* ]]; then
+          openstack baremetal node provide {{ item }};
+      fi
   with_items: "{{ total_nodes.stdout_lines | default([]) }}"
+  changed_when: false


### PR DESCRIPTION
I requested masco to add commit [1] as I thought
infrared is setting all the nodes to available after
along with introspection command. But looks like it
not doing that and all of the nodes are stuck in
manageble state. So we need to revert this commit [1]
to change their state to available.

[1] 1821dc96a3736eecd424194c2873966cf39183fa