### PR TITLE
support lab public network

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,19 @@ nvme:
       vcpus: 4
 
 [1] https://access.redhat.com/documentation/en-us/openshift_container_platform/3.11/html-single/scaling_and_performance_guide/index#providing-storage-to-an-etcd-node-using-pci-passthrough-with-openstack 
+
+## Deploying with external public network
+
+We can request scale lab team for external public network and use this for accessing overcloud VMs from outside LAB environment.
+
+1) To use this public network, set public_external_interface: true in group_vars/all.yml 
+2) Scale Lab team will enable public network on 4th interface of the nodes. For example, for 1029p nodes, this will be 'ens2f3' for osp version 14 and above, otherwise 'enp94s0f3'. Set this to external_interface variable i.e
+external_interface: ens2f3
+3) CIDR details provided by the scale lab team should be defined like below
+external_gateway: 10.1.57.1/24
+external_net_cidr: 10.1.57.0/24
+external_allocation_pools_start: 10.1.57.10
+external_allocation_pools_end: 10.1.57.30
+external_interface_default_route: 10.1.57.1
+Note: external_network_vlan_id shouldn't be defined as scale lab team configures this network with a vlan on external switch. We need to use this interface as access port and shouldn't define any VLANs on it. Also while creating overcloud external network after overcloud deployment, specify --provider:network_type as flat i.e
+neutron net-create --router:external=True --provider:network_type flat --provider:physical_network datacentre public

--- a/ci/all_osp13.yml
+++ b/ci/all_osp13.yml
@@ -93,7 +93,6 @@ inspection_iprange: 192.168.24.110,192.168.24.250
 # external network params for adding external network to
 # undercloud to access overcloud resources
 external_gateway: 172.17.5.1/24
-external_network_broadcast: 172.17.5.255
 external_network_vlan_id: 300
 clean_debug: False
 #adding changes 

--- a/external.yml
+++ b/external.yml
@@ -25,10 +25,28 @@
               ext_iface: "{{ ext_interface.stdout }}"
         when: virtual_uc != true
 
+      - name: fail when both public_external_interface and external_network_vlan_id defined
+        fail:
+          msg: Both public_external_interface and external_network_vlan_id defined
+        when: public_external_interface is defined and external_network_vlan_id is defined
+
       - name: set ext_iface
         set_fact:
           ext_iface: "{{ vm_external_interface }}"
         when: virtual_uc == true
+
+      # "Reverse path" filter prevents packets from coming in or going out on
+      #  an unexpected interface to help prevent routing loops (check with lab team).
+      # The default route on undercloud was out the primary foreman interface,
+      # so when undercloud gets packets coming in on the 4th NIC, it sends the traffic back
+      # out the foreman interface. Turning off this configuration enables to use
+      # public_external_interface i.e 4th interface
+      - name: disable rp_filter
+        shell: |
+            for f in $(find /proc/sys/net/ipv4 -name rp_filter) ; do echo 0 > $f ; done
+        become: true
+        ignore_errors: true
+        when: public_external_interface is defined
 
       - name: create vlan interface on external interface
         vars:
@@ -37,18 +55,28 @@
             ip link add link {{ ext_iface }} name {{ vlan_interface }} type vlan id {{ external_network_vlan_id }}
             ip link set dev {{ ext_iface }} up
             ip link set dev {{ vlan_interface }} up
-            ip a a {{ external_gateway }} brd {{ external_network_broadcast }} dev {{ vlan_interface }}
+            ip a a {{ external_gateway }} dev {{ vlan_interface }}
         become: true
         ignore_errors: true
+        when: external_network_vlan_id is defined
+
+      - name: add ip on when external interface is real public interface
+        shell: |
+            ip a a {{ external_gateway }} dev {{ ext_iface }}
+        become: true
+        ignore_errors: true
+        when: external_network_vlan_id is not defined
 
       - name: get default route
         shell: |
             ip r | grep default | cut -d ' ' -f5
         register: default_route
         become: true
+        when: external_network_vlan_id is defined
 
       - name: masquerade on public interface
         shell: |
             iptables -t nat -A POSTROUTING -o {{ default_route.stdout }} -j MASQUERADE
         become: true
+        when: external_network_vlan_id is defined
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -70,6 +70,22 @@ scale:
         rhel7_interfaces: [em1, em2, p1p1, p1p2]
         rhel8_interfaces: []
 
+# Scale lab can provide us public external network on 4th interface
+# We can use that to access overcloud VM's from outside undercloud.
+# To use this feature set 'public_external_interface: true' and
+# assign 4th nic to external_interface to 4th nic and
+# define external_XXXXXX parameters wth CIDR provided by lab team
+# Don't define external_network_vlan_id as lab team might have
+# created their own vlan for this external network implementation.
+#public_external_interface: false
+# set this based on osp version. For example, for 1029p nodes if the
+# osp version is 14 and above set it to ens2f3, otherwise to enp94s0f3.
+# You can refer above table or scale lab wiki for this interface name.
+#external_interface: ens2f3
+# overcloud provider external network. This external network will be created
+# after overcloud deployment as part of post deployment tasks.
+#public_net_name: public
+
 # Other lab machines have to define their interfaces through below
 # 'interfaces' variable. prepare_nic_configs.yml will use that
 # instead of deriving from
@@ -100,7 +116,6 @@ inspection_iprange: 192.168.24.110,192.168.24.250
 # external network params for adding external network to
 # undercloud to access overcloud resources
 external_gateway: 172.17.5.1/24
-external_network_broadcast: 172.17.5.255
 external_network_vlan_id: 300
 clean_debug: False
 #adding changes 

--- a/post.yml
+++ b/post.yml
@@ -10,10 +10,47 @@
       changed_when: false
       ignore_errors: true
       when: nvme is defined
+
     - name: set pci passthough for flavor
       shell: |
         source /home/stack/overcloudrc
         openstack flavor set {{ nvme.flavor.name }} --property "pci_passthrough:alias"="nvme:1"
       changed_when: false
       when: nvme is defined
+
+    - name: set public_net_name
+      set_fact:
+        public_net_name: "{{ public_net_name|default('public') }}"
+
+    - name: create external network
+      shell: |
+        source /home/stack/overcloudrc
+        neutron net-create --router:external=True --provider:network_type flat --provider:physical_network datacentre {{ public_net_name }}
+      changed_when: false
+      ignore_errors: true
+      when: external_network_vlan_id is not defined
+
+    - name: create external network
+      shell: |
+        source /home/stack/overcloudrc
+        neutron net-create --router:external=True --provider:network_type vlan --provider:physical_network datacentre --provider:segmentation_id {{ external_network_vlan_id }} {{ public_net_name }}
+      changed_when: false
+      ignore_errors: true
+      when: external_network_vlan_id is defined
+
+    - name: set alloc_end
+      vars:
+        allocation_end: "{{ external_net_cidr | ipaddr('net') | ipaddr('-2') }}"
+      set_fact:
+        alloc_end: "{{ allocation_end.split('/')[0] }}"
+
+    - name: create external subnet
+      vars:
+        gateway_address: "{{ external_gateway.split('/')[0] }}"
+        alloc_start: "{{ ((external_allocation_pools_end | ipaddr('int')) + 1) | ipaddr }}"
+      shell: |
+        source /home/stack/overcloudrc
+        neutron subnet-create --ip_version 4 --gateway $gateway_address --allocation-pool start={{ alloc_start }},end={{ alloc_end }} --disable-dhcp {{ public_net_name }} {{ external_net_cidr }}
+      changed_when: false
+      ignore_errors: true
 

--- a/prepare_nic_configs.yml
+++ b/prepare_nic_configs.yml
@@ -50,20 +50,22 @@
       - name: set control and external interfaces
         set_fact:
            ctlplane_interface: "{{ (ifaces|length > 1) | ternary(ifaces[1], ifaces[0]) }}"
+        when: ctlplane_interface is not defined
 
       - name: set external interface
         set_fact:
           external_interface: "{{ (ifaces|length > 3) | ternary(ifaces[3], ctlplane_interface) }}"
+        when: external_interface is not defined
 
       - name: set tenant interface
         set_fact:
           tenant_interface: "{{ ifaces[2] }}"
-        when: ifaces|length > 2
+        when: tenant_interface is not defined and ifaces|length > 2
 
       - name: set isolated interface
         set_fact:
           isolated_interface: "{{ ifaces[0] }}"
-        when: ifaces|length > 1
+        when: isolated_interface is not defined and ifaces|length > 1
 
       - name: set nic configs
         set_fact:

--- a/templates/compute.yaml.j2
+++ b/templates/compute.yaml.j2
@@ -169,6 +169,15 @@ resources:
     properties:
       group: script
       config:
+{% if public_external_interface is defined %}
+        list_join:
+        - ''
+        - - |
+            #!/bin/bash
+            for f in $(find /proc/sys/net/ipv4 -name rp_filter) ; do echo 0 > $f ; done
+
+          -
+{% endif %}
             str_replace:
               template:
                   get_file: {%raw%}{{ install.heat.templates.basedir }}{%endraw%}/network/scripts/run-os-net-config.sh
@@ -198,6 +207,12 @@ resources:
                               type: interface
                               name: {{ external_interface }}
 {% if external_interface_on_compute is defined %}
+{% if external_network_vlan_id is not defined %}
+                          addresses:
+                            -
+                              ip_netmask:
+                                  get_param: ExternalIpSubnet
+{% else %}
                             -
                               type: vlan
                               vlan_id:
@@ -206,6 +221,7 @@ resources:
                               -
                                 ip_netmask:
                                     get_param: ExternalIpSubnet
+{% endif %}
 {% endif %}
 {% if external_interface != ctlplane_interface %}
                         -

--- a/templates/controller.yaml.j2
+++ b/templates/controller.yaml.j2
@@ -182,6 +182,15 @@ resources:
     properties:
       group: script
       config:
+{% if public_external_interface is defined %}
+        list_join:
+        - ''
+        - - |
+            #!/bin/bash
+            for f in $(find /proc/sys/net/ipv4 -name rp_filter) ; do echo 0 > $f ; done
+
+          -
+{% endif %}
             str_replace:
               template:
                   get_file: {%raw%}{{ install.heat.templates.basedir }}{%endraw%}/network/scripts/run-os-net-config.sh
@@ -210,6 +219,12 @@ resources:
                             -
                               type: interface
                               name: {{ external_interface }}
+{% if external_network_vlan_id is not defined %}
+                          addresses:
+                            -
+                              ip_netmask:
+                                  get_param: ExternalIpSubnet
+{% else %}
                             -
                               type: vlan
                               vlan_id:
@@ -218,6 +233,7 @@ resources:
                               -
                                 ip_netmask:
                                     get_param: ExternalIpSubnet
+{% endif %}
 {% if external_interface != ctlplane_interface %}
                         -
                           type: ovs_bridge

--- a/templates/network-environment.yaml.j2
+++ b/templates/network-environment.yaml.j2
@@ -21,7 +21,9 @@ parameter_defaults:
     ExternalNetCidr: {{ external_net_cidr }}
     ExternalAllocationPools: [{'start': '{{ external_allocation_pools_start }}', 'end': '{{ external_allocation_pools_end }}' }]
     ExternalInterfaceDefaultRoute: {{ external_interface_default_route }}
+{% if external_network_vlan_id is defined %}
     ExternalNetworkVlanID: {{ external_network_vlan_id }}
+{% endif %}
     InternalApiNetCidr: {{ internal_api_net_cidr }}
     InternalApiAllocationPools: [{'start': '{{ internal_api_allocation_pools_start }}', 'end': '{{ internal_api_allocation_pools_end }}' }]
     InternalApiNetworkVlanID: {{ internal_api_network_vlan_id }}


### PR DESCRIPTION
We can request scale lab team for external public network and use
this for accessing overcloud VMs from outside LAB environment.

1) user has to set public_external_interface for jetpack to use it
   for OSP director deployment
2) user need to define external_interface, which specifies the
 interface on which lab team has enabled public network
3) define CIDR and other parameters according to README.md
4) This interface is a access port and user shouldn't define
   VLANs on it
5) jetpack will disable rp_filter on all nodes. This is needed to
   allow traffic through this public interface.
6) jetpack is enhanced to create overcloud external network after
   overcloud deployment. When public network is enabled, jetpack
   will create the network as neutron flat provider network.