### PR TITLE
fix variable undefined error

### DIFF
--- a/tasks/delete_introspection_failed_nodes.yml
+++ b/tasks/delete_introspection_failed_nodes.yml
@@ -33,7 +33,7 @@
   shell: |
       source ~/stackrc
       openstack baremetal node delete {{ item }}
-  with_items: "{{ failed_nodes_uuids }}"
+  with_items: "{{ failed_nodes_uuids | default([]) }}"
   changed_when: false
   ignore_errors: true
 


### PR DESCRIPTION
some time receving `failed_nodes_uuids` variable not defined,
eventhough the error is ignored it is good to fix