### PR TITLE
install os asynchronously

### DIFF
--- a/scale_compute_vms.yml
+++ b/scale_compute_vms.yml
@@ -35,15 +35,26 @@
          hostname_list: "{{ hostname_list|default([]) + [item.stdout] }}"
       with_items: "{{ host_list.results }}"
 
-    - include_tasks: tasks/install_os.yml
+    - name: install os
       vars:
         chassis_password:  "{{ instackenv_content.nodes[0].pm_password }}"
         needed_os: "{{ (lab_name == 'scale') | ternary('CentOS 7', 'CentOS 7.7') }}"
         hypervisor_host: "{{ hyp }}"
         hypervisor_password: "{{ ansible_ssh_pass }}"
+      include_tasks: tasks/install_os.yml
       with_items: "{{ hostname_list }}"
       loop_control:
         loop_var: hyp
+
+    - name: Wait for hypervisors to be avaialable
+      async_status:
+        jid: "{{ item }}"
+      register: install_tasks
+      until: install_tasks.finished
+      retries: 300
+      delay: 10
+      with_items: "{{ async_install }}"
+      when: async_install is defined
 
     - include_tasks: tasks/copykeys.yml
       vars:

--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -10,11 +10,25 @@
         16: 8.1
         16.1: 8.2
   tasks:
-    - include_tasks: tasks/install_os.yml
+    - name: set async_install to empty list
+      set_fact:
+        async_install: []
+
+    - name: install os on undercloud node
       vars:
         needed_os: "RHEL {{ osp_rhel_mapping[osp_release|float] }}"
         hypervisor_host: "{{ undercloud_hostname }}"
         hypervisor_password: "{{ ansible_ssh_pass }}"
+      include_tasks: tasks/install_os.yml
+
+    - name: Wait for undercloud to be avaialable
+      async_status:
+        jid: "{{ item }}"
+      register: install_uc
+      until: install_uc.finished
+      retries: 300
+      delay: 10
+      with_items: "{{ async_install }}"
 
     - name: list oc_instackenv_content
       shell: |

--- a/tasks/install_os.yml
+++ b/tasks/install_os.yml
@@ -59,7 +59,6 @@
         ansible_user: root
         ansible_python_interpreter: "{{ hammer_python_interpreter }}"
 
-
     - name: power cycle hypervisor host (Supermicro)
       shell: ipmitool -I lanplus -H mgmt-{{ hypervisor_host }} -U quads -P {{ chassis_password }} chassis power cycle
       when: vendor is defined and vendor == "supermicro"
@@ -88,23 +87,24 @@
         chdir: "{{ ansible_user_dir }}/badfish/src/badfish"
       when: vendor is defined and vendor == "dell"
 
-    - name: wait for 420 seconds before checking for hypervisor
+    - name: wait for 120 seconds before checking for hypervisor
       wait_for:
-        timeout: 420
-
-    - name: waiting for the hypervisor to be available
-      wait_for:
-        port: 22
-        host: "{{ hypervisor_host }}"
-        search_regex: OpenSSH
-        timeout: 30
-      register: hyp_reachable
-      delegate_to: localhost
-      retries: 100
-      until: hyp_reachable is succeeded
-
-    - name: maintain list of os installed hypervisors
-      set_fact:
-        hypervisors_os_installed: "{{ (hypervisors_os_installed | default([]) ) + [ hypervisor_host ] }}"
+        timeout: 120
   when: (os_install is defined)
+
+- name: waiting for the hypervisor to be available
+  wait_for:
+    port: 22
+    host: "{{ hypervisor_host }}"
+    timeout: 3000
+    connect_timeout: 30
+    sleep: 5
+  register: hyp_reachable
+  delegate_to: localhost
+  async: 3000
+  poll: 0
+
+- name: save install jids
+  set_fact:
+    async_install: "{{ async_install|default([]) + [hyp_reachable.ansible_job_id] }}"
 


### PR DESCRIPTION
When Jetpack has to install OS on several machines, this will speed
up only when run in parallel. Scale cloud simulation requires
CentOS  on all the lab machines, so we need to install
asynchronously.