### PR TITLE
Fix inventory_dir issue

### DIFF
--- a/add_undercloud_to_inventory.yml
+++ b/add_undercloud_to_inventory.yml
@@ -8,6 +8,11 @@
       vars:
         hostname: "{{ undercloud_hostname }}"
         user: "stack"
+    - name: add localhost to inventory file
+      add_host:
+        name: "localhost"
+        groups: "local"
+        ansible_connection: "local"
     - name: add undercloud_host to inventory file
       add_host:
         name: "undercloud"


### PR DESCRIPTION
[1] We are getting this error becuase of multihypervisor changes.
Multihypervisor changes were updating inventory files. But not
sure how exactly those changes are causing this issue.

Ansible issue [2] was talking about setting inventory_dir to
NULL when multiple inventory files exists. This can be fixed
if we add localhost to inventory file (earlier we were adding
 this but might be missing from the file because of
refresh_inventory), so adding again here.

[1] https://github.com/redhat-performance/jetpack/issues/253
[2] https://github.com/ansible/ansible/issues/30901

Fixes #253