### PR TITLE
remove postrouting masquerade

### DIFF
--- a/ocp_on_osp.yml
+++ b/ocp_on_osp.yml
@@ -8,15 +8,6 @@
         dir: vars
         files_matching: shift_stack_vars.yaml
 
-    - name: add MASQUERADE rule
-      iptables:
-        table: nat
-        chain: POSTROUTING
-        out_interface: '{{ ansible_default_ipv4.interface }}'
-        jump: MASQUERADE
-      become_user: root
-      become: yes
-
     - name: create flavor
       os_nova_flavor:
         cloud: "overcloud"


### PR DESCRIPTION
we are adding it while deploying OSP, so removing here.
while using external network we should not do masquerade