### PR TITLE
Fixes rebuilt of undercloud while re-deploying overcloud

### DIFF
--- a/tasks/install_os.yml
+++ b/tasks/install_os.yml
@@ -5,9 +5,12 @@
 
 - name: check redhat release in hypervsior as root and stack users
   shell: |
-    sshpass -p {{ hypervisor_password }}  ssh -o 'PreferredAuthentications=password' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -q {{ item }}@{{ hypervisor_host }} 'cat /etc/redhat-release'
+    sshpass -p {{ item[0] }}  ssh -o 'PreferredAuthentications=password' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -q {{ item[1] }}@{{ hypervisor_host }} 'cat /etc/redhat-release'
   register: rhel_release
-  loop: ['root', 'stack']
+  with_together:
+    - [ "{{ hypervisor_password }}", 'stack']
+    - ['root', 'stack']
+
   ignore_errors: true
 
 - name: set os_install when installed OS version not matching with the needed


### PR DESCRIPTION
This PR fixes the task:[check redhat release in hypervsior as root and stack users] to use a correct password for the stack user
Fixes #268