### PR TITLE
Override max_concurrent_builds set by infrared

### DIFF
--- a/overcloud.yml
+++ b/overcloud.yml
@@ -28,6 +28,28 @@
           dest: "/home/stack/firstboot-nvme.yaml"
         when: passthrough_nvme is defined or mount_nvme is defined
 
+      - block:
+          - name: adjust max number of concurrent builds to default (override infrared)
+            ini_file:
+                path: /var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf
+                section: DEFAULT
+                option: max_concurrent_builds
+                value: 10
+            become: yes
+
+          - name:  get nova services
+            shell: systemctl list-units | grep 'nova.*.service' |  awk {'print$1'}
+            register: nova_services
+            become: yes
+
+          - name: restart nova services
+            systemd:
+              name: "{{ item }}"
+              state: restarted
+            with_items: "{{ nova_services.stdout_lines }}"
+            become: yes
+        when: osp_release >= 12
+
 - hosts: localhost
   gather_facts: yes
   tasks:
@@ -84,21 +106,21 @@
             NovaSchedulerAvailableFilters: ['nova.scheduler.filters.all_filters'],
             NovaSchedulerMaxAttempts: "{{ compute_count }}",
             NovaPCIPassthrough: [{
-                vendor_id: "{{ nvme.vendor_id }}",
-                product_id: "{{ nvme.product_id }}",
-                address: "{{ nvme.address }}" }],
+                vendor_id: "{{ passthrough_nvme.vendor_id }}",
+                product_id: "{{ passthrough_nvme.product_id }}",
+                address: "{{ passthrough_nvme.address }}" }],
             ControllerExtraConfig: {
                 "nova::pci::aliases": [{
                     name: 'nvme',
-                    vendor_id: "{{ nvme.vendor_id }}",
-                    product_id: "{{ nvme.product_id }}",
+                    vendor_id: "{{ passthrough_nvme.vendor_id }}",
+                    product_id: "{{ passthrough_nvme.product_id }}",
                     device_type: 'type-PCI'}]
             },
             ComputeExtraConfig: {
                 "nova::pci::aliases": [{
                     name: 'nvme',
-                    vendor_id: "{{ nvme.vendor_id }}",
-                    product_id: "{{ nvme.product_id }}",
+                    vendor_id: "{{ passthrough_nvme.vendor_id }}",
+                    product_id: "{{ passthrough_nvme.product_id }}",
                     device_type: 'type-PCI'}]
              },
              ComputeKernelArgs: "intel_iommu=on iommu=pt",

--- a/post.yml
+++ b/post.yml
@@ -6,7 +6,7 @@
     - name: create nvme flavor
       shell: |
         source /home/stack/overcloudrc
-        openstack flavor create --ram {{ nvme.flavor.ram }} --disk {{ nvme.flavor.disk }} --vcpus {{ nvme.flavor.vcpus }} --public {{ nvme.flavor.name }}
+        openstack flavor create --ram {{ passthrough_nvme.flavor.ram }} --disk {{ passthrough_nvme.flavor.disk }} --vcpus {{ passthrough_nvme.flavor.vcpus }} --public {{ passthrough_nvme.flavor.name }}
       changed_when: false
       ignore_errors: true
       when: passthrough_nvme is defined
@@ -14,7 +14,7 @@
     - name: set pci passthough for flavor
       shell: |
         source /home/stack/overcloudrc
-        openstack flavor set {{ nvme.flavor.name }} --property "pci_passthrough:alias"="nvme:1"
+        openstack flavor set {{ passthrough_nvme.flavor.name }} --property "pci_passthrough:alias"="nvme:1"
       changed_when: false
       when: passthrough_nvme is defined
 


### PR DESCRIPTION
Infrared changes the max_concurrent_builds from 10 to 5.
This commit helps set that back to 10 for faster deploys.

Fixes: #272

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>