### PR TITLE
use nvme for nova ephemeral disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ resource_registry:
 In the above case, jetpack copies firstboot-nvme.yaml from jetpack/files/firstboot-nvme.yaml to undercloud's /home/stack folder, if it doesn't exit in the undercloud at /home/stack/firstboot-nvme.yaml.
 
 
-*nvme* need to be configured to pass overcloud compute node's non-volatile memory express device directly to overcloud VM. Read [1] for details. ```flavor``` is used to create openstack flavor after the deployment in Jetpack's post module. We can get the nvme device details with the [get_nvme_details.sh](scripts/get_nvme_details.sh) script
+*passthrough_nvme* need to be configured to pass overcloud compute node's non-volatile memory express device directly to overcloud VM. Read [1] for details. ```flavor``` is used to create openstack flavor after the deployment in Jetpack's post module. We can get the nvme device details with the [get_nvme_details.sh](scripts/get_nvme_details.sh) script
 
 Set the parameters in group_vars like below
-nvme:
+passthrough_nvme:
     vendor_id: '144d'
     product_id: 'a804'
     address: '01:00.0'

--- a/ci/all_osp13.yml
+++ b/ci/all_osp13.yml
@@ -141,9 +141,14 @@ vm_image_url:
 #neutron_backend: ovn
 #ocp installation
 shift_stack: false
+
+# define mount_nvme to mount /var/lib/nova on nvme device
+# to use nvme storage for nova instances as ephemeral disk
+#mount_nvme: true
+
 # enable nvme parameters
 # README has details about how to get these values
-#nvme:
+#passthrough_nvme:
 #    vendor_id: '144d'
 #    product_id: 'a804'
 #    address: '01:00.0'

--- a/ci/ocp_jetpack_vars.yml
+++ b/ci/ocp_jetpack_vars.yml
@@ -185,9 +185,13 @@ composable_roles: false
 # controller_ifaces: []
 #controller_machine_type: "1029p"
 
+# define mount_nvme to mount /var/lib/nova on nvme device
+# to use nvme storage for nova instances as ephemeral disk
+#mount_nvme: true
+
 # enable nvme parameters
 # README has details about how to get these values
-nvme:
+passthrough_nvme:
     vendor_id: '144d'
     product_id: 'a804'
     address: '01:00.0'

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -168,9 +168,14 @@ shift_stack: false
 #installs browbeat, if this variable is not defined or set true
 #skips browbeat installation, only if the variable set false
 browbeat: true
+
+# define mount_nvme to mount /var/lib/nova on nvme device
+# to use nvme storage for nova instances as ephemeral disk
+#mount_nvme: true
+
 # enable nvme parameters
 # README has details about how to get these values
-#nvme:
+#passthrough_nvme:
 #    vendor_id: '144d'
 #    product_id: 'a804'
 #    address: '01:00.0'

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -26,7 +26,7 @@
         template:
           src: "firstboot-nvme.yaml.j2"
           dest: "/home/stack/firstboot-nvme.yaml"
-        when: nvme is defined
+        when: passthrough_nvme is defined or mount_nvme is defined
 
 - hosts: localhost
   gather_facts: yes
@@ -105,14 +105,14 @@
           }
         set_fact:
           parameter_defaults: "{{ parameter_defaults|default({}) | combine(nvme_params) }}"
-        when: nvme is defined
+        when: passthrough_nvme is defined
 
       - name: set resource_registry nvme parameters
         vars:
           res_reg: "{{ resource_registry|default([]) }}"
         set_fact:
           resource_registry: "{{ res_reg + ['OS::TripleO::NodeUserData=/home/stack/firstboot-nvme.yaml'] }}"
-        when: nvme is defined
+        when: passthrough_nvme is defined or mount_nvme is defined
 
       - name: add tripleo_heat_templates to template
         set_fact:

--- a/post.yml
+++ b/post.yml
@@ -9,14 +9,14 @@
         openstack flavor create --ram {{ nvme.flavor.ram }} --disk {{ nvme.flavor.disk }} --vcpus {{ nvme.flavor.vcpus }} --public {{ nvme.flavor.name }}
       changed_when: false
       ignore_errors: true
-      when: nvme is defined
+      when: passthrough_nvme is defined
 
     - name: set pci passthough for flavor
       shell: |
         source /home/stack/overcloudrc
         openstack flavor set {{ nvme.flavor.name }} --property "pci_passthrough:alias"="nvme:1"
       changed_when: false
-      when: nvme is defined
+      when: passthrough_nvme is defined
 
     - name: set public_net_name
       set_fact:

--- a/templates/firstboot-nvme.yaml.j2
+++ b/templates/firstboot-nvme.yaml.j2
@@ -31,9 +31,18 @@ resources:
             set -x
             FORMAT='compute'
             if [[ $(hostname) == *$FORMAT* ]] ; then
-              sed "s/^\(GRUB_CMDLINE_LINUX=\".*\)\"/\1 $KERNEL_ARGS\"/g" -i /etc/default/grub ;
-              grub2-mkconfig -o /etc/grub2.cfg
-              reboot
+              {% if mount_nvme is not defined and passthrough_nvme is defined %} 
+                sed "s/^\(GRUB_CMDLINE_LINUX=\".*\)\"/\1 $KERNEL_ARGS\"/g" -i /etc/default/grub ;
+                grub2-mkconfig -o /etc/grub2.cfg
+                reboot
+              {% endif %}
+              {% if mount_nvme is defined and passthrough_nvme is not defined %} 
+                mkdir -p /var/lib/nova
+                mkfs -t xfs -f /dev/nvme0n1
+                mount /dev/nvme0n1 /var/lib/nova
+                chmod a+w /var/lib/nova
+                echo UUID=`sudo blkid -s UUID -o value /dev/nvme0n1` /var/lib/nova xfs discard,defaults,nofail 0 2 | sudo tee -a /etc/fstab
+              {% endif %}
             fi
           params:
             $KERNEL_ARGS: {get_param: ComputeKernelArgs}


### PR DESCRIPTION
This will mount nvme device on compute node and will use that as
nova ephemeral storage so that instances are booted on nvme device.