### PR TITLE
restructure the tags

### DIFF
--- a/add_undercloud_to_inventory.yml
+++ b/add_undercloud_to_inventory.yml
@@ -8,6 +8,8 @@
       vars:
         hostname: "{{ undercloud_hostname }}"
         user: "stack"
+      tags: undercloud, tag, overcloud
+
     - name: add localhost to inventory file
       add_host:
         name: "localhost"

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -14,7 +14,14 @@
         when: sshkey.stat.exists == False
 
       - name: load instackenv file
-        include_tasks: tasks/load_instackenv.yml
+        import_tasks: tasks/load_instackenv.yml
+        tags:
+          - undercloud
+          - introspect
+          - tag
+          - composable
+          - external
+          - overcloud
 
       - name: setup infrared
         include_tasks: tasks/setup_infrared.yml
@@ -53,6 +60,7 @@
         vars:
           lab_vars: "{{ (lab_name == 'scale') | ternary(scale, alias) }}"
         when: lab_name in ['scale', 'alias']
+        tags: undercloud, introspect, tag, composable, external, overcloud
 
       - block:
           - name: set machines_types of overcloud nodes
@@ -70,6 +78,7 @@
         vars:
           lab_vars: "{{ (lab_name == 'scale') | ternary(scale, alias) }}"
         when: lab_name in ['scale', 'alias'] and virtual_uc != true
+        tags: undercloud, introspect, tag, composable, external, overcloud
 
       # use of a local time server is essential or at least a good idea for Ceph, Kerberos, Redis,
       # maybe Kubernetes, and other components sensitive to server time skew

--- a/cleanup.yml
+++ b/cleanup.yml
@@ -4,26 +4,32 @@
         file:
             path: "{{ infrared_dir }}"
             state: absent
+
       - name: remove {{ infrared_workspaces_dir }}
         file:
             path: "{{ infrared_workspaces_dir }}"
             state: absent
+
       - name: remove {{ instackenv_file }}
         file:
             path: "{{ instackenv_file }}"
             state: absent
+
       - name: remove overcloud_instackenv.json
         file:
             path: "~/overcloud_instackenv.json"
             state: absent
+
       - name: remove nic-configs virt
         file:
             path: "{{ ansible_user_dir }}/virt"
             state: absent
+
       - name: remove nic-configs virt_4nics
         file:
             path: "{{ ansible_user_dir }}/virt_4nics"
             state: absent
+
       - name: Remove undercloud.conf
         file:
             path: "{{ ansible_user_dir }}/undercloud.conf"

--- a/main.yml
+++ b/main.yml
@@ -1,14 +1,10 @@
 ---
 - import_playbook: bootstrap.yml
-  tags:
-    - always
 
 - import_playbook: scale_compute_vms.yml
   when: scale_compute_vms == true
 
 - import_playbook: setup_undercloud.yml
-  tags:
-    - always
   when: virtual_uc != true
 
 - import_playbook: virtual_undercloud.yml
@@ -17,17 +13,23 @@
   when: virtual_uc == true
 
 - import_playbook: add_undercloud_to_inventory.yml
-  tags:
-    - always
 
 - import_playbook: prepare_nic_configs.yml
   tags:
-    - always
+    - undercloud
+    - introspect
+    - tag
+    - external
+    - overcloud
   when: composable_roles == false
 
 - import_playbook: composable_prepare_nic_configs.yml
   tags:
-    - always
+    - undercloud
+    - introspect
+    - tag
+    - external
+    - overcloud
   when: composable_roles
 
 - import_playbook: undercloud.yml

--- a/tasks/get_interpreter.yml
+++ b/tasks/get_interpreter.yml
@@ -4,7 +4,9 @@
     ssh -o 'PreferredAuthentications=publickey' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile /dev/null' {{ user }}@{{ hostname }} /usr/bin/python --version
   register: python_version
   ignore_errors: true
+  tags: undercloud, tag, overcloud
 
 - name: python interpreter
   set_fact:
     python_interpreter: "{{ (python_version.stderr_lines|length > 0 and 'Python' in python_version.stderr) | ternary('/usr/bin/python', '/usr/libexec/platform-python') }}"
+  tags: undercloud, tag, overcloud


### PR DESCRIPTION
This PR helps to redefine the tags so that only the required facts are generated while using tags.
Example:
ansible-playbook main.yaml -t undercloud
If the playbook main.yml is already run once and then user wants to use tag undercloud, it triggers only some specific tasks to deploy undercloud. It similarly works for the other tags as well.