### PR TITLE
Revert "Override max_concurrent_builds set by infrared"

### DIFF
--- a/overcloud.yml
+++ b/overcloud.yml
@@ -28,28 +28,6 @@
           dest: "/home/stack/firstboot-nvme.yaml"
         when: passthrough_nvme is defined or mount_nvme is defined
 
-      - block:
-          - name: adjust max number of concurrent builds to default (override infrared)
-            ini_file:
-                path: /var/lib/config-data/puppet-generated/nova/etc/nova/nova.conf
-                section: DEFAULT
-                option: max_concurrent_builds
-                value: 10
-            become: yes
-
-          - name:  get nova services
-            shell: systemctl list-units | grep 'nova.*.service' |  awk {'print$1'}
-            register: nova_services
-            become: yes
-
-          - name: restart nova services
-            systemd:
-              name: "{{ item }}"
-              state: restarted
-            with_items: "{{ nova_services.stdout_lines }}"
-            become: yes
-        when: osp_release >= 12
-
 - hosts: localhost
   gather_facts: yes
   tasks:


### PR DESCRIPTION
Reverts redhat-performance/jetpack#283.

This feature is failing in OSP 16 with the following error 
"msg": "Unable to start service tripleo_nova_scheduler_healthcheck.service: Job for tripleo_nova_scheduler_healthcheck.service failed because the control process exited with error code.\nSee \"systemctl status tripleo_nova_scheduler_healthcheck.service\" and \"journalctl -xe\" for details.\n"

can be added once tested with osp 16