### PR TITLE
Enabling nvme passthrough on selective nodes

### DIFF
--- a/ci/all_osp13.yml
+++ b/ci/all_osp13.yml
@@ -159,6 +159,8 @@ vlan_provider_network: false
 #      ram: 16384
 #      disk: 40
 #      vcpus: 4
+#pci_node_count: 0
+#pci_node_type: '1029u'
 
 #For Nova-less provisioning enable the variable
 novaless_prov: false

--- a/composable.yml
+++ b/composable.yml
@@ -44,11 +44,42 @@
         line: "  HostnameFormatDefault: 'compute{{ item }}-%index%'"
       with_items: "{{ machine_types }}"
 
+    - name: copy role for computePCI
+      command: |
+        cp -r ~/roles/Compute.yaml ~/roles/Compute{{ item }}PCI.yaml
+      when: item == pci_node_type and passthrough_nvme is defined
+      with_items: "{{ machine_types }}"
+
+    - name: replace control plane interface PCI
+      lineinfile:
+        path: "/home/stack/roles/Compute{{ item }}PCI.yaml"
+        regexp: '- name:'
+        line: "- name: Compute{{ item }}PCI"
+      when: item == pci_node_type and passthrough_nvme is defined
+      with_items: "{{ machine_types }}"
+
+    - name: replace control plane interface PCI
+      lineinfile:
+        path: "/home/stack/roles/Compute{{ item }}PCI.yaml"
+        regexp: '  HostnameFormatDefault:'
+        line: "  HostnameFormatDefault: '%stackname%-compute{{ item }}pci-%index%'"
+      when: item == pci_node_type and passthrough_nvme is defined
+      with_items: "{{ machine_types }}"
+
     - name: set roles
       vars:
         roles: "{{ ('Controller' + ' CephStorage') if ceph_enabled else 'Controller' }}"
       set_fact:
         roles: "{{ roles + ' Compute' + item }}"
+      when: passthrough_nvme is not defined
+      with_items: "{{ machine_types }}"
+
+    - name: set roles
+      vars:
+        roles: "{{ 'Controller' + ' CephStorage' + ( ' Compute' + pci_node_type + 'PCI') if ceph_enabled else 'Controller' + ( ' Compute' + pci_node_type + 'PCI')  }}"
+      set_fact:
+        roles: "{{ roles + ' Compute' + item }}"
+      when: passthrough_nvme is defined and pci_node_type is defined
       with_items: "{{ machine_types }}"
 
     - name: generate roles_data

--- a/composable_prepare_nic_configs.yml
+++ b/composable_prepare_nic_configs.yml
@@ -236,3 +236,9 @@
               force: yes
 
         when: ceph_enabled
+
+      - name: subtract the pci nodes from the the machine count
+        set_fact:
+          machine_count: "{{ machine_count | combine({item.key: (item.value |int - ((item.key == pci_node_type)|ternary(pci_node_count, 0)))}) }}"
+        with_dict: "{{ machine_count }}"
+        when: passthrough_nvme is defined and pci_node_count is defined

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -191,6 +191,9 @@ browbeat: true
 #      ram: 16384
 #      disk: 40
 #      vcpus: 4
+#pci_node_count: 0
+#pci_node_type: '1029u'
+
 
 #For Nova-less provisioning enable the variable
 novaless_prov: false

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -100,10 +100,12 @@
             NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter'],
             NovaSchedulerAvailableFilters: ['nova.scheduler.filters.all_filters'],
             NovaSchedulerMaxAttempts: "{{ compute_count }}",
-            NovaPCIPassthrough: [{
-                vendor_id: "{{ passthrough_nvme.vendor_id }}",
-                product_id: "{{ passthrough_nvme.product_id }}",
-                address: "{{ passthrough_nvme.address }}" }],
+            ControllerParameters: {
+                NovaPCIPassthrough: [{
+                    vendor_id: "{{ passthrough_nvme.vendor_id }}",
+                    product_id: "{{ passthrough_nvme.product_id }}",
+                    address: "{{ passthrough_nvme.address }}" }]
+            },
             ControllerExtraConfig: {
                 "nova::pci::aliases": [{
                     name: 'nvme',
@@ -111,6 +113,12 @@
                     product_id: "{{ passthrough_nvme.product_id }}",
                     device_type: 'type-PCI'}]
             },
+            ComputeParameters: {
+                NovaPCIPassthrough: [{
+                    vendor_id: "{{ passthrough_nvme.vendor_id }}",
+                    product_id: "{{ passthrough_nvme.product_id }}",
+                    address: "{{ passthrough_nvme.address }}" }]
+             },
             ComputeExtraConfig: {
                 "nova::pci::aliases": [{
                     name: 'nvme',
@@ -146,6 +154,20 @@
             dest: "{{ infrared_dir }}/plugins/tripleo-overcloud/vars/overcloud/templates/extra.yml"
             content: "{{ config_template | to_nice_yaml }}"
         when: config_template is defined
+
+      - name: update extra.yml
+        lineinfile:
+          path: "{{ infrared_dir }}/plugins/tripleo-overcloud/vars/overcloud/templates/extra.yml"
+          regexp: 'ComputeExtraConfig'
+          line: "{{ '        Compute' + pci_node_type + 'PCIExtraConfig:' }}"
+        when: passthrough_nvme is defined
+
+      - name: update extra.yml
+        lineinfile:
+          path: "{{ infrared_dir }}/plugins/tripleo-overcloud/vars/overcloud/templates/extra.yml"
+          regexp: 'ComputeParameters'
+          line: "{{ '        Compute' + pci_node_type + 'PCIParameters:' }}"
+        when: passthrough_nvme is defined
 
       # tripleo_heat_templates and resource_registry will define the files.
       # Check if these exist in the undercloud and copy them from jetpack/files

--- a/templates/firstboot-nvme.yaml.j2
+++ b/templates/firstboot-nvme.yaml.j2
@@ -29,14 +29,18 @@ resources:
           template: |
             #!/bin/bash
             set -x
-            FORMAT='compute'
+            FORMAT='pci'
+            FORMAT_MOUNT='compute'
             if [[ $(hostname) == *$FORMAT* ]] ; then
-              {% if mount_nvme is not defined and passthrough_nvme is defined %} 
+              echo "passthrough_nvme"
+              {% if passthrough_nvme is defined %}
                 sed "s/^\(GRUB_CMDLINE_LINUX=\".*\)\"/\1 $KERNEL_ARGS\"/g" -i /etc/default/grub ;
                 grub2-mkconfig -o /etc/grub2.cfg
                 reboot
               {% endif %}
-              {% if mount_nvme is defined and passthrough_nvme is not defined %} 
+            elif [[ $(hostname) != *$FORMAT* ]] && [[ $(hostname) == *$FORMAT_MOUNT* ]] ; then
+              echo "mount_nvme"
+              {% if mount_nvme is defined %}
                 mkdir -p /var/lib/nova
                 mkfs -t xfs -f /dev/nvme0n1
                 mount /dev/nvme0n1 /var/lib/nova
@@ -51,4 +55,3 @@ resources:
 outputs:
   OS::stack_id:
     value: {get_resource: userdata}
-

--- a/templates/network-environment.yaml.j2
+++ b/templates/network-environment.yaml.j2
@@ -23,7 +23,9 @@ resource_registry:
 {% if ceph_enabled %}
   OS::TripleO::CephStorage::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/ceph-storage.yaml
 {% endif %}
-
+{% if composable_roles == true and passthrough_nvme is defined %}
+  OS::TripleO::Compute{{ pci_node_type }}PCI::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/compute_{{ pci_node_type }}.yaml
+{% endif %}
 
 parameter_defaults:
 {%raw%}{% if not install.network.render.templates|default(False) %} {%endraw%}

--- a/templates/nodes_data.yml.j2
+++ b/templates/nodes_data.yml.j2
@@ -44,6 +44,8 @@ parameter_defaults:
 {% endif %}
 {% if ceph_enabled %}
   CephStorageCount: {{ ceph_node_count }}
+{% if composable_roles == true and passthrough_nvme is defined %}
+  Compute{{ pci_node_type }}PCICount: {{ pci_node_count }}
 {% endif %}
 
 {% for node_type in machine_types %}
@@ -51,4 +53,7 @@ parameter_defaults:
 {% endfor %}
 {% if ceph_enabled %}
   OvercloudCephStorageFlavor: baremetal{{ ceph_machine_type }}
+{% endif %}
+{% if composable_roles == true and passthrough_nvme is defined %}
+  OvercloudCompute{{ pci_node_type }}PCIFlavor: baremetal{{ pci_node_type }}
 {% endif %}


### PR DESCRIPTION
#304 
#311 
In group_vars/all.yml you need to specify the pci_node_count and pci_node_type on which you want to enable the nvme passthrough.
Changing the flavor names for compute{{machine_type}} to baremetal{{machine_type}} so that it can be used for custom roles like
Ceph, PCI.
In composable.yml create a custom role as Compute{{machine_type}}PCI.
Overcloud.yml- rearrange the nvme params specific to controller and Compute and update extra.yml replace ComputeParameters to Compute{{pci_node_type}}PCIParameters:
so that these nvme params are enabled on only ComputePCI nodes.
