### PR TITLE
use local time server when possible

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -70,3 +70,20 @@
         vars:
           lab_vars: "{{ (lab_name == 'scale') | ternary(scale, alias) }}"
         when: lab_name in ['scale', 'alias'] and virtual_uc != true
+
+      # use of a local time server is essential or at least a good idea for Ceph, Kerberos, Redis,
+      # maybe Kubernetes, and other components sensitive to server time skew
+
+      - name: default to corporate time server if lab not recognized
+        set_fact:
+          time_servers: ["clock.redhat.com", "clock2.redhat.com"]
+
+      - name: use bos.redhat.com time servers for Alias lab in Westford
+        set_fact:
+          time_servers: ["clock1.bos.redhat.com", "clock2.bos.redhat.com"]
+        when: lab_name == "alias"
+
+      - name: use rdu2.redhat.com time servers for Scale Lab in Raleigh NC USA
+        set_fact:
+          time_servers: ["clock1.rdu2.redhat.com"]
+        when: lab_name == "scale"

--- a/templates/undercloud.conf.j2
+++ b/templates/undercloud.conf.j2
@@ -1,7 +1,7 @@
 [DEFAULT]
 local_interface = {{ undercloud_local_interface }}
 local_ip = {{ gateway }}/{{ subnet_mask }}
-undercloud_ntp_servers = clock.redhat.com,clock2.redhat.com
+undercloud_ntp_servers = {{ time_servers | join(",") }}
 {% if clean_nodes %}
 clean_nodes = True
 {% endif %}


### PR DESCRIPTION
Do not merge this yet, still in test, but it needs review.

use a local time server (i.e. in same site or city) to minimize time skew between overcloud nodes.
This benefits Ceph, Kerberos, Redis, and other software that depends on server time synchronization.
I'd like this kind of per-site info to be outside the code and in a separate config file so it can be easily changed later on, 
but not sure where to put it
