### PR TITLE
[WIP] fix the issues caused when clean_nodes enabled

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -119,6 +119,8 @@ inspection_iprange: 192.168.24.110,192.168.24.250
 # undercloud to access overcloud resources
 external_gateway: 172.17.5.1/24
 external_network_vlan_id: 300
+#Note:when clean_nodes: true it takes longer time to move to available
+#state( specially during introspection and when overcloud is deleted)
 clean_nodes: False
 #adding changes 
 external_net_cidr: 172.17.5.0/24

--- a/tasks/delete_introspection_failed_nodes.yml
+++ b/tasks/delete_introspection_failed_nodes.yml
@@ -88,6 +88,11 @@
   register: total_nodes
   changed_when: false
 
+- name: wait for 360 seconds before checking the nodes are available
+  wait_for:
+     timeout: 360
+  when: clean_nodes
+
 - name: set provision state of all nodes to available
   shell: |
       source ~/stackrc;

--- a/tasks/install_os.yml
+++ b/tasks/install_os.yml
@@ -38,6 +38,27 @@
       ignore_errors: true
       when: hypervisor_host == undercloud_hostname
 
+    - name: get all nodes
+      shell: |
+        source ~/stackrc
+        openstack baremetal node list -f value -c UUID
+      register: get_nodes
+      changed_when: false
+      when: clean_nodes
+      ignore_errors: true
+
+    - name: wait for nodes to be in available state
+      shell: |
+        source ~/stackrc;
+        export PROV_STATE=$(openstack baremetal node show {{ item }} -c provision_state -f value);
+        if [[ $PROV_STATE != *"available"* ]]; then
+            sleep 180
+        fi
+      with_items: "{{ get_nodes.stdout_lines | default([]) }}"
+      changed_when: false
+      when: clean_nodes
+      ignore_errors: true
+
     - name: set hammer build command
       vars:
         medium: "{{ ('CentOS' in os_install) | ternary('CentOS Local', 'RHEL Local') }}"


### PR DESCRIPTION
when clean_nodes enabled
- In tasks/install_os.yml, after the overcloud delete the overcloud nodes are still in cleaning state and then move to available state. So I have added a task to ensure the nodes move to available state
- In tasks/delete_introspection_failed_nodes.yml, after the introspection for the nodes to move to available state it takes longer then default deployment, so I have added a wait time of 360 seconds