### PR TITLE
Add support for Ceph deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,25 @@ Requirements
 1) Undercloud and Controller nodes should be of same machine type
    Example:
    controller_count = 3, then it will consider the first node in instackenv.json as  undercloud and the next three nodes as controllers
-2) set composable_roles: true true in group_vars/all.yml
+2) set composable_roles: true in group_vars/all.yml
+
+## Deployment with Ceph
+On homogeneous set of machine type to deploy OSP with Ceph, set the following variables in group_vars/all.yml
+   `ceph_node_count - to number ceph nodes`
+   `ceph_enabled set to true to enable Ceph based deployment`
+   `storage_node_disks- specify the disks for example storage_node_disks: ['/dev/nvme0n1'],
+                        if you do not specify it get set based on the introspection
+                        data`
+   `osd_pool_default_pg_num - user needs to calculate and set it based on storage_node_disks`
+   `osd_pool_default_pgp_num - user needs to calculate and set it based on storage_node_disks`
+   `osd_objectstore can be set to filestore or bluestore. By default set to filestore`
+   `osd_scenario can be set to collocated, non-collocated (for filestore) or lvm for (bluestore)`
+
+For OSP deploy with Ceph using Composable Roles, After setting the above specified vars you need to set two additional vars in group_vars/all.yml i.e ceph_ifaces, ceph_machine_type.
+   Example:
+   For OSP16.1,
+   `ceph_machine_type: '1029p'`
+   `ceph_ifaces: [ens2f0, ens2f1, ens2f2, ens2f3]`
+
+Note: User can customize [internal.yml.j2](templates/internal.yml.j2) template for Ceph deployment based on their
+      requirement if needed

--- a/ci/all_osp13.yml
+++ b/ci/all_osp13.yml
@@ -15,6 +15,7 @@ baseurl: http://download.eng.pek2.redhat.com/released/RHEL-7/7.9/Server/x86_64/o
 controller_count: 1
 # No need to set compute_count. This will be set to all remaining nodes, which is calclulated in overcloud.yml
 compute_count: 1
+ceph_node_count: 0
 set_boot_order: false
 hammer_host: hwstore.example.com
 alias:
@@ -162,13 +163,24 @@ shift_stack: false
 novaless_prov: false
 scale_compute_vms: false
 
+new_nodes_instack: "{{ playbook_dir }}/newnodes.json"
+
 # Enables composable_roles
 # If lab_name not in [scale, alias] set undercloud_local_interface.
 #Specify the controller ifaces for composable roles explicitly in
 #case you need specific machines as controllers. Else default controller
 #machine type is the first node in overcloud_instackenv.json
 composable_roles: false
-# controller_ifaces: []
+#controller_ifaces: []
 #controller_machine_type: "1029p"
+#ceph_ifaces: []
+#ceph_machine_type:
 
-new_nodes_instack: "{{ playbook_dir }}/newnodes.json"
+#Ceph deployment
+ceph_enabled: false
+osd_scenario: lvm
+osd_objectstore: bluestore
+#storage_node_disks: ['/dev/nvme0n1']
+#osd_pool_default_pg_num:
+#osd_pool_default_pgp_num:
+

--- a/composable.yml
+++ b/composable.yml
@@ -7,7 +7,6 @@
         infrared_oc_deploy_template:  "{{ ansible_user_dir }}/.infrared/plugins/tripleo-overcloud/templates/overcloud_deploy.sh.j2"
       shell: |
         cp   {{ oc_deploy_template }} {{ infrared_oc_deploy_template }}
-
 - hosts: undercloud
   vars:
     machine_types:  "{{ hostvars['localhost']['machine_types'] }}"
@@ -15,18 +14,17 @@
     - name: create flavors
       shell: |
         source ~/stackrc
-        openstack flavor create --id auto --ram 4096 --disk 40 --vcpus 1 compute{{ item }}
-        openstack flavor set --property "capabilities:boot_option"="local" --property "capabilities:profile"="compute{{ item }}" compute{{ item }}
-        openstack flavor set compute{{ item }} --property "resources:VCPU"="0"
-        openstack flavor set compute{{ item }} --property "resources:MEMORY_MB"="0"
-        openstack flavor set compute{{ item }} --property "resources:DISK_GB"="0"
-        openstack flavor set compute{{ item }} --property "resources:CUSTOM_BAREMETAL"="1"
+        openstack flavor create --id auto --ram 4096 --disk 40 --vcpus 1 baremetal{{ item }}
+        openstack flavor set --property "capabilities:boot_option"="local" --property "capabilities:profile"="baremetal{{ item }}" baremetal{{ item }}
+        openstack flavor set baremetal{{ item }} --property "resources:VCPU"="0"
+        openstack flavor set baremetal{{ item }} --property "resources:MEMORY_MB"="0"
+        openstack flavor set baremetal{{ item }} --property "resources:DISK_GB"="0"
+        openstack flavor set baremetal{{ item }} --property "resources:CUSTOM_BAREMETAL"="1"
       with_items: "{{ machine_types }}"
 
     - name: copy roles directory
       command: |
         cp -r /usr/share/openstack-tripleo-heat-templates/roles /home/stack
-
     - name: copy roles directory
       command:  |
         cp -r ~/roles/Compute.yaml ~/roles/Compute{{ item }}.yaml
@@ -43,12 +41,12 @@
       lineinfile:
         path: "/home/stack/roles/Compute{{ item }}.yaml"
         regexp: '  HostnameFormatDefault:'
-        line: "  HostnameFormatDefault: '%stackname%-compute{{ item }}-%index%'"
+        line: "  HostnameFormatDefault: 'compute{{ item }}-%index%'"
       with_items: "{{ machine_types }}"
 
     - name: set roles
       vars:
-        roles: "Controller"
+        roles: "{{ ('Controller' + ' CephStorage') if ceph_enabled else 'Controller' }}"
       set_fact:
         roles: "{{ roles + ' Compute' + item }}"
       with_items: "{{ machine_types }}"
@@ -66,7 +64,7 @@
         for i in $(openstack baremetal node list --format value -c UUID); do
           if [[ `openstack baremetal node show $i --fields driver_info -f json | jq '.driver_info.ipmi_address'` =~ {{ item }} ]]
           then
-            openstack baremetal node set $i --property capabilities=profile:compute{{ item }},cpu_vt:true,cpu_hugepages:true,boot_option:local,cpu_txt:true,cpu_aes:true,cpu_hugepages_1g:true,boot_mode:bios
+            openstack baremetal node set $i --property capabilities=profile:baremetal{{ item }},cpu_vt:true,cpu_hugepages:true,boot_option:local,cpu_txt:true,cpu_aes:true,cpu_hugepages_1g:true,boot_mode:bios
           fi
         done
       with_items: "{{ machine_types }}"

--- a/composable_prepare_nic_configs.yml
+++ b/composable_prepare_nic_configs.yml
@@ -99,6 +99,11 @@
         with_items:
           - "{{ ifaces }}"
 
+      - name: set storage interface for custom roles
+        set_fact:
+          storage_interfaces: "{{ isolated_interfaces }}"
+        when: ceph_enabled and isolated_interfaces is defined
+
       - name: remove duplicates from machine types
         set_fact:
           machine_types: "{{ machine_types | unique }}"
@@ -185,3 +190,40 @@
          - "{{ external_interfaces }}"
          - "{{ tenant_interfaces }}"
          - "{{ isolated_interfaces }}"
+
+      - block:
+          - name: fail if ceph_machine_type or ceph_ifaces are not defined
+            fail:
+              msg: check if ceph_machine_type and ceph_ifaces are defined
+            when: ceph_machine_type is not defined or ceph_ifaces is  not defined
+
+          - name: set fact ceph machine type
+            set_fact:
+              ceph_machine_type: "{{ (machine_count[ceph_machine_type]|int >= ceph_node_count|int) | ternary(ceph_machine_type, false) }}"
+
+          - name: fail when insufficient nodes for ceph
+            fail:
+              msg: Not enough nodes of same machine_type for ceph
+            when: ceph_machine_type == false
+
+          - name: set fact for ceph ext iface
+            set_fact:
+              ceph_external_interface: "{{ (ceph_ifaces|length > 1) | ternary(ceph_ifaces[1], ceph_ifaces[0]) }}"
+              ceph_ctlplane_interface: "{{ (ceph_ifaces|length > 1) | ternary(ceph_ifaces[1], ceph_ifaces[0]) }}"
+
+          - name: set fact for ceph storage iface
+            set_fact:
+              ceph_storage_interface: "{{ ceph_ifaces[0] }}"
+            when: ceph_ifaces|length > 1
+
+          - name: prepare ceph-storage.yaml.j2
+            vars:
+              ctlplane_interface: "{{ ceph_ctlplane_interface }}"
+              external_interface: "{{ ceph_external_interface }}"
+              storage_interface: "{{ ceph_storage_interface }}"
+            template:
+              src: ceph-storage.yaml.j2
+              dest: "{{ nic_config_path }}/ceph-storage.yaml.j2"
+              force: yes
+
+        when: ceph_enabled

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -15,6 +15,7 @@ baseurl: http://download.eng.pek2.redhat.com/released/RHEL-7/7.9/Server/x86_64/o
 controller_count: 3
 # No need to set compute_count. This will be set to all remaining nodes, which is calclulated in overcloud.yml
 #compute_count: 1
+ceph_node_count: 0
 set_boot_order: false
 hammer_host: hwstore.example.com
 alias:
@@ -119,7 +120,7 @@ inspection_iprange: 192.168.24.110,192.168.24.250
 # undercloud to access overcloud resources
 external_gateway: 172.17.5.1/24
 external_network_vlan_id: 300
-clean_nodes: False
+clean_nodes: false
 #adding changes 
 external_net_cidr: 172.17.5.0/24
 external_allocation_pools_start: 172.17.5.50
@@ -208,6 +209,19 @@ scale_compute_vms: false
 #case you need specific machines as controllers. Else default controller
 #machine type is the first node in overcloud_instackenv.json
 composable_roles: false
-# controller_ifaces: []
+#controller_ifaces: []
 #controller_machine_type: "1029p"
+#ceph_ifaces: []
+#ceph_machine_type:
 
+
+#Ceph deployment params
+ceph_enabled: false
+osd_scenario: lvm
+osd_objectstore: bluestore
+
+#Note:By default storage_node_disks can be detected automatically
+#using introspection data
+#storage_node_disks: ['/dev/nvme0n1']
+#osd_pool_default_pg_num:
+#osd_pool_default_pgp_num:

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -2,38 +2,55 @@
 - hosts: undercloud
   gather_facts: yes
   tasks:
-      # RHBZ 1756492
-      - name: exclude ceph images
-        lineinfile:
-          path: /home/stack/containers-prepare-parameter.yaml
-          insertafter: "- push_destination: true"
-          line: '    excludes:'
-        when: osp_release > 13
-      - name: exclude ceph images
-        lineinfile:
-          path: /home/stack/containers-prepare-parameter.yaml
-          insertafter: "    excludes:"
-          line: '    - ceph'
-        when: osp_release > 13
-      - name: get tht version
-        shell: |
-          grep  "heat_template_version" /usr/share/openstack-tripleo-heat-templates/overcloud.j2.yaml | cut -d ':' -f2
-        register: tht_version
-      - name: set heat_template_version
-        set_fact:
-          heat_template_version: "{{ tht_version.stdout }}"
-      - name: generate firstboot-nvme.yaml
-        template:
-          src: "firstboot-nvme.yaml.j2"
-          dest: "/home/stack/firstboot-nvme.yaml"
-        when: passthrough_nvme is defined or mount_nvme is defined
+    - block:
+        # RHBZ 1756492
+        - name: exclude ceph images
+          lineinfile:
+            path: /home/stack/containers-prepare-parameter.yaml
+            insertafter: "- push_destination: true"
+            line: '    excludes:'
+
+        - name: exclude ceph images
+          lineinfile:
+            path: /home/stack/containers-prepare-parameter.yaml
+            insertafter: "    excludes:"
+            line: '    - ceph'
+
+      when: (ceph_enabled != true) and (osp_release > 13)
+
+    - name: get tht version
+      shell: |
+        grep  "heat_template_version" /usr/share/openstack-tripleo-heat-templates/overcloud.j2.yaml | cut -d ':' -f2
+      register: tht_version
+
+    - name: set heat_template_version
+      set_fact:
+        heat_template_version: "{{ tht_version.stdout }}"
+
+    - name: generate firstboot-nvme.yaml
+      template:
+        src: "firstboot-nvme.yaml.j2"
+        dest: "/home/stack/firstboot-nvme.yaml"
+      when: passthrough_nvme is defined or mount_nvme is defined
+
+    - name: generate wipe-disks.yaml
+      template:
+        src: "firstboot-wipe-disks.yaml.j2"
+        dest: "/home/stack/wipe-disks.yaml"
+      when: ceph_enabled and (clean_nodes != true)
+
+    - name: generate wipe-disk.sh
+      template:
+        src: "wipe-disk.sh.j2"
+        dest: "/home/stack/wipe-disk.sh"
+      when: ceph_enabled and (clean_nodes != true)
 
 - hosts: localhost
   gather_facts: yes
   tasks:
       - name: Set compute count fact
         set_fact:
-            compute_count: "{{ compute_count|default(oc_instackenv_content.nodes|length - (controller_count|int)) }}"
+          compute_count: "{{ compute_count|default(oc_instackenv_content.nodes|length - (controller_count|int) - (ceph_node_count|int)) }}"
 
       - name: get nodes
         shell: |
@@ -49,13 +66,13 @@
       - block:
         - name: check registered nodes with requested node count
           debug:
-            msg: "Less nodes {{ nodes_uuids.stdout_lines|length }} registered with ironic than requested {{ compute_count|int + controller_count|int }}. So we will be adjusting controller and compute count according to registered available nodes"
-          when: nodes_uuids.stdout_lines|length < (compute_count|int + controller_count|int)
+            msg: "Less nodes {{ nodes_uuids.stdout_lines|length }} registered with ironic than requested {{ compute_count|int + controller_count|int + ceph_node_count|int }}. So we will be adjusting controller and compute count according to registered available nodes"
+          when: nodes_uuids.stdout_lines|length < (compute_count|int + controller_count|int + ceph_node_count|int)
 
         - name: Adjust compute count
           set_fact:
             compute_count: "{{ compute_count|int - 1 }}"
-          when: nodes_uuids.stdout_lines|length < (compute_count|int + controller_count|int)
+          when: nodes_uuids.stdout_lines|length < (compute_count|int + controller_count|int + ceph_node_count|int)
           with_items: "{{ nodes_uuids }}"
         when: scale_compute_vms == false
 
@@ -231,9 +248,26 @@
             include_tasks: tasks/provisioning_baremetal_nodes.yml
         when: novaless_prov
 
+      - name: set fact for storage nodes
+        set_fact:
+          storage_node_disks: "{{ hostvars['undercloud']['storage_node_disks']|unique }}"
+        when: ceph_enabled and storage_node_disks is not defined
+
+      - name: generate internal.yml.j2
+        template:
+          src: internal.yml.j2
+          dest: ~/.infrared/plugins/tripleo-overcloud/templates/storage/internal.yml.j2
+          force: yes
+        when: ceph_enabled
+
+      - name: set facts for ceph deployment
+        set_fact:
+          ceph_params: "--storage-backend ceph --storage-external no"
+        when: ceph_enabled
+
       - name: run tripleo-overcloud deploy
         shell: |
             source .venv/bin/activate
-            infrared tripleo-overcloud -vvv --version {{ osp_release }} --deployment-timeout {{ deployment_timeout | default(240) }} --build {{ osp_puddle }}  --deployment-files {{ nic_configs }} --introspect no --tagging no --deploy yes --controller-nodes {{ controller_count }} --compute-nodes {{ compute_count }} {{ oc_extra_templates | default('') }} --network-protocol ipv4 --network-backend {{ network_backend }} {{ network_type }} true --public-network false {{ oc_heat_configs | default('') }} {{ oc_config_resource | default('') }} > {{ log_directory }}/overcloud_deploy.log 2>&1
+            infrared tripleo-overcloud -vvv --version {{ osp_release }} --deployment-timeout {{ deployment_timeout | default(240) }} --build {{ osp_puddle }}  --deployment-files {{ nic_configs }} --introspect no --tagging no --deploy yes --controller-nodes {{ controller_count }} --compute-nodes {{ compute_count }} --storage-nodes {{ ceph_node_count }} {{ oc_extra_templates | default('') }} --network-protocol ipv4 --network-backend {{ network_backend }} {{ network_type }} true {{ ceph_params | default('') }} --public-network false {{ oc_heat_configs | default('') }} {{ oc_config_resource | default('') }} > {{ log_directory }}/overcloud_deploy.log 2>&1
         args:
             chdir: "{{ infrared_dir }}"

--- a/prepare_nic_configs.yml
+++ b/prepare_nic_configs.yml
@@ -74,6 +74,11 @@
           isolated_interface: "{{ ifaces[0] }}"
         when: isolated_interface is not defined and ifaces|length > 1
 
+      - name: set storage_interface
+        set_fact:
+          storage_interface: "{{ ifaces[0] }}"
+        when: storage_interface is not defined and ifaces|length > 1
+
       - name: set nic configs
         set_fact:
           nic_configs: "{{ ansible_user_dir }}/virt"
@@ -105,6 +110,13 @@
             src: "{{ (osp_release|int > 10) | ternary('compute.yaml.j2', 'osp10_compute.yaml.j2') }}"
             dest: "{{ nic_config_path }}/compute.yaml.j2"
             force: yes
+
+      - name: prepare ceph-storage.yaml.j2
+        template:
+            src: ceph-storage.yaml.j2
+            dest: "{{ nic_config_path }}/ceph-storage.yaml.j2"
+            force: yes
+        when: ceph_enabled
 
       - name: prepare compute.yaml.j2
         template:

--- a/tasks/delete_introspection_failed_nodes.yml
+++ b/tasks/delete_introspection_failed_nodes.yml
@@ -97,3 +97,49 @@
       fi
   with_items: "{{ total_nodes.stdout_lines | default([]) }}"
   changed_when: false
+  register: prov_state
+  until: prov_state is succeeded
+  retries: 3
+  delay: 30
+
+- block:
+    - name: introspection data for a nodes
+      shell: |
+        source ~/stackrc
+        openstack baremetal introspection data save {{ item }} | jq . | grep by-path | cut -d \" -f 4
+      register: storage_disks_info
+      with_items: "{{ total_nodes.stdout_lines | default([]) }}"
+      when: composable_roles != true
+
+
+    - name: introspection data for a nodes
+      shell: |
+        source ~/stackrc
+        for i in $(openstack baremetal node list --format value -c UUID); do
+          if [[ `openstack baremetal node show $i --fields driver_info -f json | jq '.driver_info.ipmi_address'` =~ {{ ceph_machine_type }} ]]
+          then
+             openstack baremetal introspection data save $i | jq . | grep by-path | cut -d \" -f 4
+          fi
+        done
+      register: storage_disks_info_comp
+      with_items: "{{ total_nodes.stdout_lines | default([]) }}"
+      when: composable_roles
+
+    - name: set fact storage_node_disks
+      set_fact:
+        storage_node_disks: "{{ storage_node_disks|default([]) + item.stdout_lines }}"
+      with_items: "{{ storage_disks_info.results }}"
+      when: composable_roles != true
+
+    - name: set fact storage_node_disks
+      set_fact:
+        storage_node_disks: "{{ storage_node_disks|default([]) + item.stdout_lines }}"
+      with_items: "{{ storage_disks_info_comp.results }}"
+      when: composable_roles
+
+  when: ceph_enabled and storage_node_disks is not defined
+
+- name: show the storage_node_disks
+  debug:
+    msg: "{{ storage_node_disks|unique }}"
+  when: ceph_enabled

--- a/templates/ceph-storage.yaml.j2
+++ b/templates/ceph-storage.yaml.j2
@@ -1,0 +1,256 @@
+heat_template_version: ocata
+
+description: >
+  Software Config to drive os-net-config to configure multiple interfaces
+  for the controller role.
+
+parameters:
+  ControlPlaneIp:
+    default: ''
+    description: IP address/subnet on the ctlplane network
+    type: string
+  ExternalIpSubnet:
+    default: ''
+    description: IP address/subnet on the external network
+    type: string
+  InternalApiIpSubnet:
+    default: ''
+    description: IP address/subnet on the internal API network
+    type: string
+  StorageIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage network
+    type: string
+  StorageMgmtIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage mgmt network
+    type: string
+  TenantIpSubnet:
+    default: ''
+    description: IP address/subnet on the tenant network
+    type: string
+  ManagementIpSubnet: # Only populated when including environments/network-management.yaml
+    default: ''
+    description: IP address/subnet on the management network
+    type: string
+  ExternalNetworkVlanID:
+    default: 10
+    description: Vlan ID for the external network traffic.
+    type: number
+  InternalApiNetworkVlanID:
+    default: 20
+    description: Vlan ID for the internal_api network traffic.
+    type: number
+  StorageNetworkVlanID:
+    default: 30
+    description: Vlan ID for the storage network traffic.
+    type: number
+  StorageMgmtNetworkVlanID:
+    default: 40
+    description: Vlan ID for the storage mgmt network traffic.
+    type: number
+  TenantNetworkVlanID:
+    default: 50
+    description: Vlan ID for the tenant network traffic.
+    type: number
+  ExternalInterfaceDefaultRoute:
+    default: '10.0.0.1'
+    description: default route for the external network
+    type: string
+  ControlPlaneSubnetCidr: # Override this via parameter_defaults
+    default: '24'
+    description: The subnet CIDR of the control plane network.
+    type: string
+  ControlPlaneDefaultRoute: # Override this via parameter_defaults
+    description: The subnet CIDR of the control plane network.
+    type: string
+  DnsServers: # Override this via parameter_defaults
+    default: []
+    description: A list of DNS servers (2 max for some implementations) that will be added to resolv.conf.
+    type: json
+  EC2MetadataIp: # Override this via parameter_defaults
+    description: The IP address of the EC2 metadata server.
+    type: string
+{%raw%}{% if install.version|openstack_release >= 15 %}{%endraw%}
+
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  StorageMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      Storage network.
+    type: number
+  StorageMgmtMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      StorageMgmt network.
+    type: number
+  InternalApiMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      InternalApi network.
+    type: number
+  TenantMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      Tenant network.
+    type: number
+  ExternalMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      External network.
+    type: number
+  ManagementMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      Management network.
+    type: number
+{%raw%}{% endif %}{%endraw%}
+
+{%raw%}{% if install.version|openstack_release >= 14 %}{%endraw%}
+
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ManagementInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the management network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+{%raw%}{% endif %}{%endraw%}
+resources:
+  OsNetConfigImpl:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      config:
+{% if public_external_interface is defined %}
+        list_join:
+        - ''
+        - - |
+            #!/bin/bash
+            for f in $(find /proc/sys/net/ipv4 -name rp_filter) ; do echo 0 > $f ; done
+
+          -
+{% endif %}
+            str_replace:
+              template:
+                  get_file: {%raw%}{{ install.heat.templates.basedir }}{%endraw%}/network/scripts/run-os-net-config.sh
+
+              params:
+                   $network_config:
+                       network_config:
+                        -
+                          type: ovs_bridge
+                          name: br-ex
+                          use_dhcp: false
+{% if external_interface == ctlplane_interface %}
+                          addresses:
+                            -
+                              ip_netmask:
+                                list_join:
+                                  - '/'
+                                  - - get_param: ControlPlaneIp
+                                    - get_param: ControlPlaneSubnetCidr
+                          routes:
+                            -
+                              ip_netmask: 169.254.169.254/32
+                              next_hop:
+                                  get_param: EC2MetadataIp
+{% endif %}
+                          members:
+                            -
+                              type: interface
+                              name: {{ external_interface }}
+                            -
+                              type: vlan
+                              vlan_id:
+                                  get_param: StorageMgmtNetworkVlanID
+                              addresses:
+                              - 
+                                ip_netmask:
+                                    get_param: StorageMgmtIpSubnet
+
+
+{% if storage_interface is defined %}
+                        - 
+                          type: ovs_bridge
+                          name: br-storage
+                          use_dhcp: false
+                          members:
+                            - 
+                              type: interface
+                              name: {{ storage_interface }}
+{% endif %}
+
+                            - 
+                              type: vlan
+                              vlan_id:
+                                  get_param: StorageNetworkVlanID
+                              addresses:
+                              - 
+                                ip_netmask:
+                                    get_param: StorageIpSubnet
+outputs:
+  OS::stack_id:
+    description: The OsNetConfigImpl resource.
+    value:
+        get_resource: OsNetConfigImpl

--- a/templates/firstboot-wipe-disks.yaml.j2
+++ b/templates/firstboot-wipe-disks.yaml.j2
@@ -1,0 +1,20 @@
+heat_template_version: 2014-10-16
+
+description: >
+  Wipe all disks (except the disk containing the root file system)
+
+resources:
+  userdata:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+      - config: {get_resource: wipe_disk}
+
+  wipe_disk:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config: {get_file: wipe-disk.sh}
+
+outputs:
+  OS::stack_id:
+    value: {get_resource: userdata}

--- a/templates/internal.yml.j2
+++ b/templates/internal.yml.j2
@@ -1,0 +1,30 @@
+{% if clean_nodes != true %}
+resource_registry:
+  OS::TripleO::NodeUserData: /home/stack/wipe-disks.yaml
+{% endif %}
+
+parameter_defaults:
+  LocalCephAnsibleFetchDirectoryBackup: /tmp/fetch_dir
+{% if ceph_node_count < 3 %}
+  CephPoolDefaultSize: {{ ceph_node_count }}
+{% else %}
+  CephPoolDefaultSize: 3
+{% endif %}
+  # when deploying a small number of osd's - < 12), it's necessary to decrease the default pg_num from 128 to get past the max 200pgs/per osd  limitation
+  CephPoolDefaultPgNum: 32
+  CephAnsiblePlaybookVerbosity: 1
+  CephAnsibleDisksConfig:
+    devices:
+{% for disk in storage_node_disks[1:] %}
+      - {{ disk }}
+{% endfor %}
+
+# the following two parameters are the defaults. Just included them here for info
+    osd_scenario: {{ osd_scenario }}
+    osd_objectstore: {{ osd_objectstore }}
+  CephAnsibleExtraConfig:
+    osd_pool_default_autoscale_mode: on
+
+  ExtraConfig:
+    ceph::profile::params::osd_pool_default_pg_num: {{ osd_pool_default_pg_num | default(32) }}
+    ceph::profile::params::osd_pool_default_pgp_num: {{ osd_pool_default_pgp_num | default(32) }}

--- a/templates/network-environment.yaml.j2
+++ b/templates/network-environment.yaml.j2
@@ -20,6 +20,10 @@ resource_registry:
   OS::TripleO::Compute::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/compute.yaml
 {% endif %}
   OS::TripleO::Controller::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/controller.yaml
+{% if ceph_enabled %}
+  OS::TripleO::CephStorage::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/ceph-storage.yaml
+{% endif %}
+
 
 parameter_defaults:
 {%raw%}{% if not install.network.render.templates|default(False) %} {%endraw%}

--- a/templates/nodes_data.yml.j2
+++ b/templates/nodes_data.yml.j2
@@ -3,8 +3,12 @@ parameter_defaults:
   ControllerCount: {{ controller_count }}
 {% if failed_nodes_machine_type is not defined %}
 {% for node_type in machine_types %}
-{% if node_type|string() == controller_machine_type|string() %}
+{% if (node_type|string() == controller_machine_type|string()) and (node_type|string() == ceph_machine_type|string()) %}
+  Compute{{ node_type }}Count: {{ machine_count[node_type]|int - controller_count|int - ceph_node_count|int }}
+{% elif node_type|string() == controller_machine_type|string() %}
   Compute{{ node_type }}Count: {{ machine_count[node_type]|int - controller_count|int }}
+{% elif node_type|string() == ceph_machine_type|string() %}
+  Compute{{ node_type }}Count: {{ machine_count[node_type]|int - ceph_node_count|int }}
 {% else %}
   Compute{{ node_type }}Count: {{ machine_count[node_type] }}
 {% endif %}
@@ -15,22 +19,36 @@ parameter_defaults:
 {% for failed_machine_type in failed_nodes_machine_type|unique %}
 {% for node_type in machine_types %}
 {% if node_type|string() == failed_machine_type|string() %}
-{% if failed_machine_type|string() == controller_machine_type|string() %}
+
+{% if (failed_machine_type|string() == controller_machine_type|string()) and  (failed_machine_type|string() == ceph_machine_type|string()) %}
+  Compute{{ node_type }}Count: {{ machine_count[node_type]|int - controller_count|int - ceph_node_count|int - failed_nodes_machine_count[failed_machine_type]|int }}
+{% elif failed_machine_type|string() == controller_machine_type|string() %}
   Compute{{ node_type }}Count: {{ machine_count[node_type]|int - controller_count|int - failed_nodes_machine_count[failed_machine_type]|int }}
+{% elif failed_machine_type|string() == ceph_machine_type|string() %}
+  Compute{{ node_type }}Count: {{ machine_count[node_type]|int - ceph_node_count|int - failed_nodes_machine_count[failed_machine_type]|int }}
 {% else %}
   Compute{{ node_type }}Count: {{ machine_count[node_type]|int - failed_nodes_machine_count[failed_machine_type]|int }}
 {% endif %}
+
+{% elif (node_type|string() == controller_machine_type|string()) and (node_type|string() == ceph_machine_type|string()) %}
+  Compute{{ node_type }}Count: {{ machine_count[node_type]|int - controller_count|int - ceph_node_count|int }}
 {% elif node_type|string() == controller_machine_type|string() %}
   Compute{{ node_type }}Count: {{ machine_count[node_type]|int - controller_count|int }}
+{% elif node_type|string() == ceph_machine_type|string() %}
+  Compute{{ node_type }}Count: {{ machine_count[node_type]|int - ceph_node_count|int }}
 {% else %}
   Compute{{ node_type }}Count: {{ machine_count[node_type] }}
 {% endif %}
 {% endfor %}
 {% endfor %}
 {% endif %}
-
+{% if ceph_enabled %}
+  CephStorageCount: {{ ceph_node_count }}
+{% endif %}
 
 {% for node_type in machine_types %}
-  OvercloudCompute{{ node_type }}Flavor: compute{{ node_type }}
+  OvercloudCompute{{ node_type }}Flavor: baremetal{{ node_type }}
 {% endfor %}
-
+{% if ceph_enabled %}
+  OvercloudCephStorageFlavor: baremetal{{ ceph_machine_type }}
+{% endif %}

--- a/templates/wipe-disk.sh.j2
+++ b/templates/wipe-disk.sh.j2
@@ -1,0 +1,28 @@
+{% if ceph_enabled %}
+#!/bin/bash
+if [[ `hostname` = *"ceph"* ]]
+then
+  echo "Number of disks detected: $(lsblk -no NAME,TYPE,MOUNTPOINT | grep "disk" | awk '{print $1}' | wc -l)"
+  for DEVICE in `lsblk -no NAME,TYPE,MOUNTPOINT | grep "disk" | awk '{print $1}'`
+  do
+    ROOTFOUND=0
+    echo "Checking /dev/$DEVICE..."
+    echo "Number of partitions on /dev/$DEVICE: $(expr $(lsblk -n /dev/$DEVICE | awk '{print $7}' | wc -l) - 1)"
+    for MOUNTS in `lsblk -n /dev/$DEVICE | awk '{print $7}'`
+    do
+      if [ "$MOUNTS" = "/" ]
+      then
+        ROOTFOUND=1
+      fi
+    done
+    if [ $ROOTFOUND = 0 ]
+    then
+      echo "Root not found in /dev/${DEVICE}"
+      echo "Wiping disk /dev/${DEVICE}"
+      sgdisk -Z /dev/${DEVICE}
+    else
+      echo "Root found in /dev/${DEVICE}"
+    fi
+  done
+fi
+{% endif %}


### PR DESCRIPTION
#326 
Update the params in group_vars/all.yml depending on your allocation, please refer README

composable.yml, create a flavor baremetal{{machine_type}} that can be used by ceph and remaining nodes and creates a custom role for Ceph

composable_prepare_nic.yml, generates nic template for ceph nodes when composable_roles is enabled

prepare_nic_configs.yml, generates nic template for ceph nodes when composable_roles is disabled

overcloud.yml, generate wipe-fs script that can be used for wiping the disks when clean_nodes is disabled. Adjust the compute node count based on ceph count and create internal.yml with Overcloud ceph node customization like CephDefaultPoolSize, pg_num so on

 tasks/delete_introspection_failed_nodes.yml, Jetpack supports auto-detection of storage_node_disks from the introspection data

templates/nodes_data.yml.j2, generates node_data.yml file that contains info about node count and flavor used
