### PR TITLE
Configurable timeout for introspection

### DIFF
--- a/ci/all_osp13.yml
+++ b/ci/all_osp13.yml
@@ -174,14 +174,18 @@ new_nodes_instack: "{{ playbook_dir }}/newnodes.json"
 composable_roles: false
 #controller_ifaces: []
 #controller_machine_type: "1029p"
-#ceph_ifaces: []
-#ceph_machine_type:
 
 #Ceph deployment
+#ceph_ifaces: []
+#ceph_machine_type:
 ceph_enabled: false
 osd_scenario: lvm
 osd_objectstore: bluestore
 #storage_node_disks: ['/dev/nvme0n1']
 #osd_pool_default_pg_num:
 #osd_pool_default_pgp_num:
+
+#Default value for introspection timeout is 2400s, but user can configure
+#the timeout for large cloud
+#introspection_timeout:
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -217,17 +217,19 @@ scale_compute_vms: false
 composable_roles: false
 #controller_ifaces: []
 #controller_machine_type: "1029p"
-#ceph_ifaces: []
-#ceph_machine_type:
-
 
 #Ceph deployment params
+#ceph_ifaces: []
+#ceph_machine_type:
 ceph_enabled: false
 osd_scenario: lvm
 osd_objectstore: bluestore
-
 #Note:By default storage_node_disks can be detected automatically
 #using introspection data
 #storage_node_disks: ['/dev/nvme0n1']
 #osd_pool_default_pg_num:
 #osd_pool_default_pgp_num:
+
+#Default value for introspection timeout is 2400s, but user can configure
+#the timeout for large cloud
+#introspection_timeout:

--- a/introspect.yml
+++ b/introspect.yml
@@ -15,7 +15,7 @@
             args:
               chdir: "{{ infrared_dir }}"
             changed_when: false
-            async: 2400
+            async: "{{ introspection_timeout | default(2400) }}"
             poll: 60
             ignore_errors: true
         when: scale_compute_vms == false


### PR DESCRIPTION
This is needed for large cloud deployment and when cleaning is enabled  as the default timeout is not sufficient