### PR TITLE
quick fix

### DIFF
--- a/tasks/setup_infrared.yml
+++ b/tasks/setup_infrared.yml
@@ -6,7 +6,7 @@
 
 - name: clone infrared
   git:
-      repo: "https://github.com/redhat-openstack/infrared"
+      repo: "https://github.com/asyedham/infrared.git"
       dest: "{{ infrared_dir }}"
       force: yes
 


### PR DESCRIPTION
[skip-ci]
The latest infrared changes is causing the overcloud deployment to fail
so excluding those changes temporarily