### PR TITLE
Fix infrared template issue

### DIFF
--- a/overcloud.yml
+++ b/overcloud.yml
@@ -249,6 +249,10 @@
 
       - name: set extra template facts
         set_fact:
+          oc_extra_templates: "--overcloud-templates None"
+
+      - name: set extra template facts
+        set_fact:
           oc_extra_templates: "--overcloud-templates {{ infrared_dir }}/plugins/tripleo-overcloud/vars/overcloud/templates/extra.yml"
         when: ( extra_templates is defined and extra_templates|length>0 ) or ( parameter_defaults is defined and parameter_defaults.keys()|length>0 )
 
@@ -290,6 +294,6 @@
       - name: run tripleo-overcloud deploy
         shell: |
             source .venv/bin/activate
-            infrared tripleo-overcloud -vvv --version {{ osp_release }} --deployment-timeout {{ deployment_timeout | default(240) }} --build {{ osp_puddle }}  --deployment-files {{ nic_configs }} --introspect no --tagging no --deploy yes --controller-nodes {{ controller_count }} --compute-nodes {{ compute_count }} --storage-nodes {{ ceph_node_count }} {{ oc_extra_templates | default('') }} --network-protocol ipv4 --network-backend {{ network_backend }} {{ network_type }} true {{ ceph_params | default('') }} --public-network false {{ oc_heat_configs | default('') }} {{ oc_config_resource | default('') }} > {{ log_directory }}/overcloud_deploy.log 2>&1
+            infrared tripleo-overcloud -vvv --version {{ osp_release }} --deployment-timeout {{ deployment_timeout | default(240) }} --build {{ osp_puddle }}  --deployment-files {{ nic_configs }} --introspect no --tagging no --deploy yes --controller-nodes {{ controller_count }} --compute-nodes {{ compute_count }} --storage-nodes {{ ceph_node_count }} {{ oc_extra_templates }} --network-protocol ipv4 --network-backend {{ network_backend }} {{ network_type }} true {{ ceph_params | default('') }} --public-network false {{ oc_heat_configs | default('') }} {{ oc_config_resource | default('') }} > {{ log_directory }}/overcloud_deploy.log 2>&1
         args:
             chdir: "{{ infrared_dir }}"

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -249,7 +249,7 @@
 
       - name: set extra template facts
         set_fact:
-          oc_extra_templates: "--overcloud-templates None"
+          oc_extra_templates: "--overcloud-templates none"
 
       - name: set extra template facts
         set_fact:

--- a/tasks/setup_infrared.yml
+++ b/tasks/setup_infrared.yml
@@ -6,7 +6,7 @@
 
 - name: clone infrared
   git:
-      repo: "https://github.com/asyedham/infrared.git"
+      repo: "https://github.com/redhat-openstack/infrared"
       dest: "{{ infrared_dir }}"
       force: yes
 


### PR DESCRIPTION
As we can see in issue 361, infrared commit [1] started directly
using install.overcloud.templates without checking if the user
has defined it or not. This is forcing us to define it to 'None'
in Jetpack when we don't want to pass extra templates.

Also reverted commit [2]

[1] bfbc4a552439b3bb21b318ab9cc5766ded8c72eb
[2] e624d6603b9a0f34e16c782edc8177875ddc1e86

Closes #361