### PR TITLE
OSP13_RHEL7.9_RELEASE_FIX

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -11,7 +11,6 @@ ansible_ssh_pass: password
 ansible_ssh_key: "{{ ansible_user_dir }}/.ssh/id_rsa"
 osp_release: 13
 osp_puddle: passed_phase2
-baseurl: http://download.eng.pek2.redhat.com/released/RHEL-7/7.9/Server/x86_64/os/
 controller_count: 3
 # No need to set compute_count. This will be set to all remaining nodes, which is calclulated in overcloud.yml
 #compute_count: 1

--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -30,18 +30,19 @@
       delay: 10
       with_items: "{{ async_install }}"
 
-    - block:
-        - name: preapare RHEL79.repo (OSP13)
-          template:
-            src: RHEL.repo.j2
-            dest: /etc/yum.repos.d/RHEL79.repo
-          delegate_to: "{{ undercloud_hostname }}"
-          vars:
-            ansible_python_interpreter: "{{ python_interpreter }}"
-            ansible_user: "root"
+    - include_tasks: tasks/get_interpreter.yml
+      vars:
+        hostname: "{{ undercloud_hostname }}"
+        user: "root"
+      ignore_errors: yes
 
+    - block:
         - name: update os to RHEL 7.9
           shell: |
+             rm -rf /etc/yum.repos.d/epel*.repo;
+             rm -rf /etc/yum.repos.d/RHEL*.repo;
+             yum install -y http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm;
+             rhos-release 13 -p passed_phase2 -r 7.9;
              yum update -y
           delegate_to: "{{ undercloud_hostname }}"
           vars:

--- a/templates/RHEL.repo.j2
+++ b/templates/RHEL.repo.j2
@@ -1,7 +1,0 @@
-{% if osp_release == 13 %}
-[rhel-7-server79]
-name=Red Hat Enterprise Linux - 7.9 - Server
-baseurl={{ baseurl }}
-enabled=1
-gpgcheck=0
-{% endif %}


### PR DESCRIPTION
FIx the unnecessary repo file to upgrade RHEL7.9 for the OSP-13 release.
- modified:   group_vars/all.yml
- modified:   setup_undercloud.yml
- deleted:    templates/RHEL.repo.j2


