### PR TITLE
Jetpack support for OSP13(RHEL7.9) & OSP16.2(RHEL8.4)

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -11,7 +11,6 @@ ansible_ssh_pass: password
 ansible_ssh_key: "{{ ansible_user_dir }}/.ssh/id_rsa"
 osp_release: 13
 osp_puddle: passed_phase2
-baseurl: http://download.eng.pek2.redhat.com/released/RHEL-7/7.9/Server/x86_64/os/
 controller_count: 3
 # No need to set compute_count. This will be set to all remaining nodes, which is calclulated in overcloud.yml
 #compute_count: 1

--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -40,7 +40,7 @@
     - include_tasks: tasks/update_repo.yml
       when: osp_release == 13 or 16.2
 
-      ## The 
+      ## This block of task execute when condition meet for 13 and 16.2
     - block:
         - name: update os to RHEL 7.9
           shell: |

--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -9,6 +9,7 @@
         15: 8.0
         16: 8.1
         16.1: 8.2
+        16.2: 8.4
   tasks:
     - name: set async_install to empty list
       set_fact:
@@ -30,24 +31,38 @@
       delay: 10
       with_items: "{{ async_install }}"
 
-    - block:
-        - name: preapare RHEL79.repo (OSP13)
-          template:
-            src: RHEL.repo.j2
-            dest: /etc/yum.repos.d/RHEL79.repo
-          delegate_to: "{{ undercloud_hostname }}"
-          vars:
-            ansible_python_interpreter: "{{ python_interpreter }}"
-            ansible_user: "root"
+    - include_tasks: tasks/get_interpreter.yml
+      vars:
+        hostname: "{{ undercloud_hostname }}"
+        user: "root"
+      ignore_errors: yes
 
+    - include_tasks: tasks/update_repo.yml
+      when: osp_release == 13 or 16.2
+
+      ## The 
+    - block:
         - name: update os to RHEL 7.9
           shell: |
+             rhos-release 13 -p passed_phase2 -r 7.9;
              yum update -y
           delegate_to: "{{ undercloud_hostname }}"
           vars:
             ansible_python_interpreter: "{{ python_interpreter }}"
             ansible_user: "root"
-      when: osp_release == 13
+        when: osp_release == 13
+
+        - name: update os to RHEL 8.4
+          shell: |
+             rhos-release 16.2 -p passed_phase2 -r 8.4;
+             dnf -y module disable virt:rhel container-tools:rhel8;
+             dnf -y module enable virt:av container-tools:2.0;
+             dnf update -y;
+          delegate_to: "{{ undercloud_hostname }}"
+          vars:
+            ansible_python_interpreter: "{{ python_interpreter }}"
+            ansible_user: "root"
+        when: osp_release == 16.2
 
     - name: list oc_instackenv_content
       shell: |

--- a/tasks/install_os.yml
+++ b/tasks/install_os.yml
@@ -25,10 +25,15 @@
     os_install: "RHEL 7.8"
   when: needed_os == "RHEL 7.9"
 
+- name: set os_install before updating os RHEL 8.4
+  set_fact:
+    os_install: "RHEL 8.2"
+  when: needed_os == "RHEL 8.4"
+
 - name: set os_install for forceful provisioning
   set_fact:
     os_install: "{{ needed_os }}"
-  when: force_reprovision == true and needed_os != "RHEL 7.9"
+  when: force_reprovision == true and needed_os not in ["RHEL 7.9", "RHEL 8.4"]
 
 - name: Reboot if OS install needed
   block:

--- a/tasks/update_repo.yml
+++ b/tasks/update_repo.yml
@@ -1,0 +1,20 @@
+---
+- name: Delete the the existing EPEL and RHEL Repos configured by Foreman
+  file:
+    path: "/etc/yum.repos.d/{{ item }}"
+    state: absent
+  with_items:
+    - epel*.repo
+    - RHEL*.repo
+  delegate_to: "{{ undercloud_hostname }}"
+  vars:
+    ansible_python_interpreter: "{{ python_interpreter }}"
+    ansible_user: "root"
+
+- name : Install the rhos-release-latest rpm
+  shell: |
+     rpm -ivh http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm;
+  delegate_to: "{{ undercloud_hostname }}"
+  vars:
+    ansible_python_interpreter: "{{ python_interpreter }}"
+    ansible_user: "root"

--- a/templates/RHEL.repo.j2
+++ b/templates/RHEL.repo.j2
@@ -1,7 +1,0 @@
-{% if osp_release == 13 %}
-[rhel-7-server79]
-name=Red Hat Enterprise Linux - 7.9 - Server
-baseurl={{ baseurl }}
-enabled=1
-gpgcheck=0
-{% endif %}


### PR DESCRIPTION
Set OSP16.2 release with RHEL8.4 base OS. 

- modified:   setup_undercloud.yml
- modified:   tasks/install_os.yml

**Note**: OSP16.2 Undercloud deployed with RHEL8.4 base OS. But the overcloud still have 8.3 as the overcloud image has not yet upgraded by the OSP and it doesn't create any conflict. Also in future, it won't the Jetpack code as there are no dependencies.