### PR TITLE
fix scale simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ For OSP deploy with Ceph using Composable Roles, After setting the above specifi
 Note: User can customize [internal.yml.j2](templates/internal.yml.j2) template for Ceph deployment based on their
       requirement if needed
 
+## scale simulation
+This feature allows scale testing on limited nodes environment. It helps in scale testing tripleo. Jetpack simulates VMs as Openstack overcloud compute nodes. Jetpack will use lab machines as hypervisors to create VMs and then use these VMs as Openstack overcloud nodes. Undercloud and Controller nodes will be still baremetal nodes.
+
+Requirements
+1) User has to install RHEL 8.2 on all hypervisors
+2) User has to copy ssh keys (i.e ~/.ssh) to all hypervisors. Each hypervisor should be able to login to other hypervisors.
+3) In group_vars/all.yml, set
+```
+scale_compute_vms: true
+undercloud_public_host: 192.168.0.2
+undercloud_admin_host: 192.168.0.3
+cidr: 192.168.0.0/16
+gateway: 192.168.0.1
+dhcp_start: 192.168.0.5
+dhcp_end: 192.168.10.254
+inspection_iprange: 192.168.11.1,192.168.20.254
+```
+
 # Limitations
 1. Overcloud nodes with existing software raid disks pre-deployment will lead to deployment failures due to [ironic bug](https://bugzilla.redhat.com/show_bug.cgi?id=1933256).
    It is common for storage-class servers like 6049p to be predeployed with software raid. There are 2 workarounds until this ironic bug is resolved.

--- a/scale_compute_vms.yml
+++ b/scale_compute_vms.yml
@@ -35,36 +35,6 @@
          hostname_list: "{{ hostname_list|default([]) + [item.stdout] }}"
       with_items: "{{ host_list.results }}"
 
-    - name: install os
-      vars:
-        chassis_password:  "{{ instackenv_content.nodes[0].pm_password }}"
-        needed_os: "{{ (lab_name == 'scale') | ternary('CentOS 7', 'CentOS 7.7') }}"
-        hypervisor_host: "{{ hyp }}"
-        hypervisor_password: "{{ ansible_ssh_pass }}"
-      include_tasks: tasks/install_os.yml
-      with_items: "{{ hostname_list }}"
-      loop_control:
-        loop_var: hyp
-
-    - name: Wait for hypervisors to be available
-      async_status:
-        jid: "{{ item }}"
-      register: install_tasks
-      until: install_tasks.finished
-      retries: 300
-      delay: 10
-      with_items: "{{ async_install }}"
-      when: async_install is defined
-
-    - include_tasks: tasks/copykeys.yml
-      vars:
-        hostname: "{{ hyp }}"
-        ssh_user: "root"
-        id_file:  "{{ ansible_ssh_key }}"
-      with_items: "{{ hostname_list }}"
-      loop_control:
-        loop_var: hyp
-
     - include_tasks: tasks/get_interpreter.yml
       vars:
         hostname: "{{ hostname_list[0] }}"
@@ -82,49 +52,11 @@
       loop_control:
         loop_var: hyp
 
-    # create ssh key on the first hypervisor
-    - name: check if ssh key exists
-      stat:
-        path: "{{ ansible_ssh_key }}"
-      register: sshkey
-      delegate_to: "{{ groups.hypervisor|first }}"
-
-    - name:  Generate ssh key
-      shell:
-        ssh-keygen -q -N "" -f {{ ansible_ssh_key }}
-      when: sshkey.stat.exists == False
-      delegate_to: "{{ groups.hypervisor|first }}"
-
-    - name:  install sshpass on first hypervisor
-      package:
-        name: sshpass
-        state: installed
-      delegate_to: "{{ groups.hypervisor|first }}"
-
-    # copy first hypervisor key to all hypervisors (as vbmc ports are created on first hypervisor)
-    - name: remove key
-      shell: |
-        ssh-keygen -R {{ hyp }}
-      changed_when: false
-      with_items: "{{ groups.hypervisor }}"
-      loop_control:
-        loop_var: hyp
-      delegate_to: "{{ groups.hypervisor|first }}"
-      ignore_errors: true
-
-    - name: add ssh key
-      shell: |
-        echo '{{ ansible_ssh_pass }}' | sshpass ssh-copy-id -i {{ ansible_ssh_key }} -o 'StrictHostKeyChecking no' -f root@{{ hyp }}
-      changed_when: false
-      with_items: "{{ groups.hypervisor }}"
-      loop_control:
-        loop_var: hyp
-      delegate_to: "{{ groups.hypervisor|first }}"
     - name: set rhel 7 interfaces for hypervisors
       vars:
         lab_vars: "{{ (lab_name == 'scale') | ternary(scale, alias) }}"
       set_fact:
-        hyp_ifaces: "{{ lab_vars['machine_types'][vendor][machine_type]['rhel7_interfaces'] }}"
+        hyp_ifaces: "{{ lab_vars['machine_types'][vendor][machine_type]['rhel8_interfaces'] }}"
 
 
 - hosts: hypervisor
@@ -138,7 +70,7 @@
       package:
         name: "{{ item }}"
         state: installed
-      loop: ['gcc', 'libffi-devel', 'openssl-devel', 'python-virtualenv', 'libvirt', 'qemu-kvm', 'libselinux-python']
+      loop: ['gcc', 'libffi-devel', 'openssl-devel', 'python3-virtualenv', 'libvirt', 'qemu-kvm']
 
     - name: start libvirtd
       systemd:

--- a/tasks/setup_infrared.yml
+++ b/tasks/setup_infrared.yml
@@ -21,13 +21,6 @@
     chdir: "{{ infrared_dir }}"
   changed_when: false
 
-- name: use infrared patch
-  shell: |
-    git fetch "https://review.gerrithub.io/redhat-openstack/infrared" refs/changes/07/502407/1 && git checkout FETCH_HEAD
-  args:
-    chdir: "{{ infrared_dir }}"
-  when: scale_compute_vms == true
-
 - name: change deployment timeout in infrared code
   shell: |
     sed -ri 's/^(\s*)(maximum\s*:\s*240\s*$)/\1maximum: 2400/' {{ infrared_dir }}/plugins/tripleo-overcloud/plugin.spec


### PR DESCRIPTION
1. Remove installing OS on hypervisors and copying keys. Let user
   do this manually. This will reduce complexity in scale
   simulation code.
2. As all infrared changes related to scale simulation are merged,
   we avoid using infrared patches in the code.