### PR TITLE
larger external net allocation pool

### DIFF
--- a/ci/all_osp13.yml
+++ b/ci/all_osp13.yml
@@ -96,14 +96,17 @@ dhcp_end: 192.168.24.105
 inspection_iprange: 192.168.24.110,192.168.24.250
 # external network params for adding external network to
 # undercloud to access overcloud resources
-external_gateway: 172.17.5.1/24
+external_gateway: 172.18.0.1/16
 external_network_vlan_id: 300
 clean_nodes: True
 #adding changes 
-external_net_cidr: 172.17.5.0/24
-external_allocation_pools_start: 172.17.5.50
-external_allocation_pools_end: 172.17.5.150
-external_interface_default_route: 172.17.5.1
+external_net_cidr: 172.18.0.0/16
+external_allocation_pools_start: 172.18.0.50
+external_allocation_pools_end: 172.18.0.150
+external_interface_default_route: 172.18.0.1
+overcloud_external_net_alloc_start: 172.18.1.1
+overcloud_external_net_alloc_end: 172.18.254.254
+
 #internal
 internal_api_net_cidr: 172.17.1.0/24
 internal_api_allocation_pools_start: 172.17.1.10

--- a/ci/ocp_jetpack_vars.yml
+++ b/ci/ocp_jetpack_vars.yml
@@ -131,14 +131,16 @@ dhcp_end: 192.168.24.105
 inspection_iprange: 192.168.24.110,192.168.24.250
 # external network params for adding external network to
 # undercloud to access overcloud resources
-external_gateway: "{{ lookup('env', 'OSP_EXTERNAL_GATEWAY')|default('172.17.5.1/24', true) }}"
+external_gateway: "{{ lookup('env', 'OSP_EXTERNAL_GATEWAY')|default('172.18.0.1/16', true) }}"
 #external_network_vlan_id: 300
 clean_nodes: false
 #adding changes 
-external_net_cidr: "{{ lookup('env', 'OSP_EXTERNAL_NET_CIDR')|default('172.17.5.0/24', true) }}"
-external_allocation_pools_start: "{{ lookup('env', 'OSP_EXTERNAL_ALLOCATION_POOLS_START')|default('172.17.5.50', true) }}"
-external_allocation_pools_end: "{{ lookup('env', 'OSP_EXTERNAL_ALLOCATION_POOLS_END')|default('172.17.5.150', true) }}"
-external_interface_default_route: "{{ lookup('env', 'OSP_EXTERNAL_INTERFACE_DEFAULT_ROUTE')|default('172.17.5.1', true) }}"
+external_net_cidr: "{{ lookup('env', 'OSP_EXTERNAL_NET_CIDR')|default('172.18.0.0/16', true) }}"
+external_allocation_pools_start: "{{ lookup('env', 'OSP_EXTERNAL_ALLOCATION_POOLS_START')|default('172.18.0.50', true) }}"
+external_allocation_pools_end: "{{ lookup('env', 'OSP_EXTERNAL_ALLOCATION_POOLS_END')|default('172.18.0.150', true) }}"
+external_interface_default_route: "{{ lookup('env', 'OSP_EXTERNAL_INTERFACE_DEFAULT_ROUTE')|default('172.18.0.1', true) }}"
+overcloud_external_net_alloc_start: "{{ lookup('env', 'OSP_OVERCLOUD_EXTERNAL_NET_ALLOCATION_POOLS_START')|default('172.18.1.1', true) }}"
+overcloud_external_net_alloc_end: "{{ lookup('env', 'OSP_OVERCLOUD_EXTERNAL_NET_ALLOCATION_POOLS_END')|default('172.18.254.254', true) }}"
 
 #internal
 internal_api_net_cidr: 172.17.1.0/24

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -128,14 +128,16 @@ dhcp_end: 192.168.24.105
 inspection_iprange: 192.168.24.110,192.168.24.250
 # external network params for adding external network to
 # undercloud to access overcloud resources
-external_gateway: 172.17.5.1/24
+external_gateway: 172.18.0.1/16
 external_network_vlan_id: 300
 clean_nodes: false
 #adding changes 
-external_net_cidr: 172.17.5.0/24
-external_allocation_pools_start: 172.17.5.50
-external_allocation_pools_end: 172.17.5.150
-external_interface_default_route: 172.17.5.1
+external_net_cidr: 172.18.0.0/16
+external_allocation_pools_start: 172.18.0.50
+external_allocation_pools_end: 172.18.0.150
+external_interface_default_route: 172.18.0.1
+overcloud_external_net_alloc_start: 172.18.1.1
+overcloud_external_net_alloc_end: 172.18.254.254
 
 #internal
 internal_api_net_cidr: 172.17.1.0/24

--- a/post.yml
+++ b/post.yml
@@ -38,19 +38,12 @@
       ignore_errors: true
       when: external_network_vlan_id is defined
 
-    - name: set alloc_start
-      vars:
-        allocation_start: "{{ external_net_cidr | ipaddr('net') | ipaddr('2') }}"
-      set_fact:
-        alloc_start: "{{ allocation_start.split('/')[0] }}"
-
     - name: create external subnet
       vars:
         gateway_address: "{{ external_gateway.split('/')[0] }}"
-        alloc_end: "{{ ((external_allocation_pools_start | ipaddr('int')) - 1) | ipaddr }}"
       shell: |
         source /home/stack/overcloudrc
-        neutron subnet-create --ip_version 4 --gateway {{ gateway_address }} --allocation-pool start={{ alloc_start }},end={{ alloc_end }} --disable-dhcp {{ public_net_name }} {{ external_net_cidr }}
+        neutron subnet-create --ip_version 4 --gateway {{ gateway_address }} --allocation-pool start={{ overcloud_external_net_alloc_start }},end={{ overcloud_external_net_alloc_end }} --disable-dhcp {{ public_net_name }} {{ external_net_cidr }}
       changed_when: false
       ignore_errors: true
 


### PR DESCRIPTION
As most of us deploy OSP for scale testing and the default
172.17.5.0/24 is not sufficient for floating ips.
So we need to use 172.18.0.0/16 network for floating ip.

When we specify 172.18.0.0/16 in group_vars, post.yaml is
still using 172.18.0.2-172.18.0.24 as allocation pools for
floating ip network. So this patch removes the logic in
post.yml which calculates this allocation pool and instead
accept the values from group vars. User need to pass them
through group vars.