### PR TITLE
Fixed spelling mistake in group_vars/all.yml

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -13,7 +13,7 @@ osp_release: 13
 osp_puddle: passed_phase2
 baseurl: http://download.eng.pek2.redhat.com/released/RHEL-7/7.9/Server/x86_64/os/
 controller_count: 3
-# No need to set compute_count. This will be set to all remaining nodes, which is calclulated in overcloud.yml
+# No need to set compute_count. This will be set to all remaining nodes, which is calculated in overcloud.yml
 #compute_count: 1
 ceph_node_count: 0
 set_boot_order: true


### PR DESCRIPTION
I fixed a spelling mistake in the group_vars/all.yml file.