### PR TITLE
Optimised Jetpack Dockerfile to reduce number of layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM centos:7
 
-RUN yum -y install git
-RUN yum -y install epel-release
-RUN yum -y install ansible
+RUN yum -y install git epel-release ansible
 
 RUN git clone https://github.com/redhat-performance/jetpack.git
 


### PR DESCRIPTION
There are 3 RUN commands in the Jetpack Dockerfile that each lead to the creation of one layer in the resulting image. This PR aims to reduce the number of layers created in the Jetpack image by combining the 3 RUN commands into 1 RUN command.