### PR TITLE
fixing the node count data

### DIFF
--- a/tasks/delete_introspection_failed_nodes.yml
+++ b/tasks/delete_introspection_failed_nodes.yml
@@ -46,7 +46,7 @@
 
 - name: get the machine type of introspection failed nodes
   set_fact:
-    failed_nodes_machine_type: "{{ failed_nodes_machine_type|default([]) + [(type != '1029u')|ternary(type, (item.stdout.replace('mgmt-', '') in tn10rt) | ternary('1029utn10rt', '1029utrtp')) ] }}"
+    failed_nodes_machine_type: "{{ failed_nodes_machine_type|default([]) + [(type != '1029u')|ternary(type, (item.stdout.replace('mgmt-', '').replace('\"', '') in tn10rt) | ternary('1029utn10rt', '1029utrtp')) ] }}"
   vars:
       type: "{{ (lab_name == 'scale' | ternary(item.stdout.split('.')[0].split('-')[4], item.stdout.split('.')[0].split('-')[3])) }}"
   with_items: "{{ failed_nodes_ipmi_addr.results }}"


### PR DESCRIPTION
if introspection fails the node type is not properly added to dict
as the failed node ipmi address having the excape char in it.