### PR TITLE
Enable root password for nodes

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -108,12 +108,22 @@ interfaces:
 
 #extra_templates:
 
-#heat_configs:
+heat_configs:
+  # Enable root user password for all nodes
+  NodeRootPassword: "{{ ansible_ssh_pass }}"
+  SshServerOptions:
+    PasswordAuthentication: 'yes'
+    PermitRootLogin: 'yes'
 #if you need vlan tenant network enable the below lines
 # - NeutronNetworkType=vlan
 # - NeutronBridgeMappings=openshift:br-openshift,datacentre:br-ex
 # - NeutronNetworkVLANRanges=openshift:500:1000,datacentre:1:500
 # - ComputeParameters.NeutronBridgeMappings=openshift:br-openshift
+
+resource_registry:
+  # Enable root user password for all nodes
+  - OS::TripleO::NodeUserData=/usr/share/openstack-tripleo-heat-templates/firstboot/userdata_root_password.yaml
+  - OS::TripleO::Services::Sshd=/usr/share/openstack-tripleo-heat-templates/deployment/sshd/sshd-baremetal-puppet.yaml
 
 # containers params
 registry_mirror: redhat.com


### PR DESCRIPTION
We see Overcloud deployment failing when undercloud is unable
to ssh to the provisioned nodes. As we have remote console access
to the baremetal nodes, we can login to the node and debug
if we set root password. This patch enables root password for
the overcloud nodes.