### PR TITLE
Change ~ to {{ ansible_user_dir }} for .infrared in cleanup.yml

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -4,9 +4,9 @@
         file:
             path: "{{ infrared_dir }}"
             state: absent
-      - name: remove ~/.infrared
+      - name: remove {{ ansible_user_dir }}/.infrared
         file:
-            path: ~/.infrared
+            path: "{{ ansible_user_dir }}/.infrared"
             state: absent
       - name: remove {{ instackenv_file }}
         file:


### PR DESCRIPTION
Jenkins stores the .infrared directory in /var/lib/jenkins instead of ~. cleanup.yml should be updated to reflect this change.