### PR TITLE
Install badfish packages in badfish venv

### DIFF
--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -46,4 +46,11 @@
       requirements: "{{ ansible_user_dir }}/badfish/requirements.txt"
       virtualenv_command: /usr/bin/python3 -m venv
       virtualenv: "{{ badfish_venv }}"
+      
+  - name: Install badfish packages
+    shell: |
+      source {{ badfish_venv }}/bin/activate;
+      pip install -e .
+    args:
+      chdir: "{{ ansible_user_dir }}/badfish"
   when: virtual_uc == false or scale_compute_vms == true

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -46,7 +46,7 @@
       requirements: "{{ ansible_user_dir }}/badfish/requirements.txt"
       virtualenv_command: /usr/bin/python3 -m venv
       virtualenv: "{{ badfish_venv }}"
-      
+
   - name: Install badfish packages
     shell: |
       source {{ badfish_venv }}/bin/activate;


### PR DESCRIPTION
Badfish packages `badfish` and `helpers` are located in the directory `badfish/src`. They are required in latest changes to badfish. The badfish venv should have these packages installed.

Closes #419 