### PR TITLE
Add support  for Manila deployment

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -30,6 +30,7 @@ jobs:
         override-deps: |
           ansible==2.10.3
           ansible-lint==4.3.7
+          rich<11.0.0
         # [optional]
         # Arguments to be passed to the ansible-lint
 

--- a/common.yml
+++ b/common.yml
@@ -13,6 +13,11 @@
         set_fact:
           tn10rt: "{{ lookup('file', '~/tn10rt.html') }}"
 
+      - name: set storage-protocol-backend
+        set_fact:
+          storage_protocol_backend: ' --storage-protocol-backend nfs-ganesha'
+        when: manila_enabled
+
       - block:
           - name: set machine_type
             set_fact:

--- a/common.yml
+++ b/common.yml
@@ -7,11 +7,11 @@
       - name: get tn10rt machines list
         get_url:
           url: http://wiki.scalelab.redhat.com/1029u/
-          dest: /tmp/tn10rt.html
+          dest: ~/tn10rt.html
 
       - name: load tn10rt machines list
         set_fact:
-          tn10rt: "{{ lookup('file', '/tmp/tn10rt.html') }}"
+          tn10rt: "{{ lookup('file', '~/tn10rt.html') }}"
 
       - block:
           - name: set machine_type

--- a/composable.yml
+++ b/composable.yml
@@ -73,7 +73,15 @@
         roles: "{{ ('Controller' + ' CephStorage') if ceph_enabled else 'Controller' }}"
       set_fact:
         roles: "{{ roles + ' Compute' + item }}"
-      when: passthrough_nvme is not defined
+      when: (passthrough_nvme is not defined) and not manila_enabled
+      with_items: "{{ machine_types }}"
+
+    - name: set roles
+      vars:
+        roles: "{{ ('ControllerStorageNfs' + ' CephStorage') if ceph_enabled else 'ControllerStorageNfs' }}"
+      set_fact:
+        roles: "{{ roles + ' Compute' + item }}"
+      when: (passthrough_nvme is not defined) and manila_enabled
       with_items: "{{ machine_types }}"
 
     - name: set roles

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -168,6 +168,11 @@ storage_mgmt_net_cidr: 172.17.4.0/24
 storage_mgmt_allocation_pools_start: 172.17.4.10
 storage_mgmt_allocation_pools_end: 172.17.4.149
 storage_mgmt_network_vlan_id: 303
+#storage_nfs
+storage_nfs_net_cidr: 172.17.5.0/24
+storage_nfs_network_vlan_id: 305
+storage_nfs_allocation_pools_start: 172.17.5.10
+storage_nfs_allocation_pools_end: 172.17.5.149
 #tenant
 tenant_net_cidr: 172.17.2.0/24
 tenant_allocation_pools_start: 172.17.2.10
@@ -268,3 +273,4 @@ osd_objectstore: bluestore
 #the timeout for large cloud
 #introspection_timeout:
 foreman_url: https://foreman.example.com
+manila_enabled: false

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -253,8 +253,13 @@
 
       - name: set extra template facts
         set_fact:
+          oc_extra_templates: "--overcloud-templates docker-ceph-mds,manila-cephganesha"
+        when: manila_enabled
+
+      - name: set extra template facts
+        set_fact:
           oc_extra_templates: "--overcloud-templates {{ infrared_dir }}/plugins/tripleo-overcloud/vars/overcloud/templates/extra.yml"
-        when: ( extra_templates is defined and extra_templates|length>0 ) or ( parameter_defaults is defined and parameter_defaults.keys()|length>0 )
+        when: ( extra_templates is defined and extra_templates|length>0 ) or ( parameter_defaults is defined and parameter_defaults.keys()|length>0 ) and manila_enabled != true
 
       - name: set heat config facts
         set_fact:
@@ -299,6 +304,6 @@
       - name: run tripleo-overcloud deploy
         shell: |
             source .venv/bin/activate
-            infrared tripleo-overcloud -vvv --version {{ osp_release }} --deployment-timeout {{ deployment_timeout | default(240) }} --build {{ osp_puddle }}  --deployment-files {{ nic_configs }} --introspect no --tagging no --deploy yes --controller-nodes {{ controller_count }} --compute-nodes {{ compute_count }} --storage-nodes {{ ceph_node_count }} {{ oc_extra_templates }} --network-protocol ipv4 --network-backend {{ network_backend }} {{ network_type }} true {{ ceph_params | default('') }} --public-network false {{ oc_heat_configs | default('') }} {{ oc_config_resource | default('') }} > {{ log_directory }}/overcloud_deploy.log 2>&1
+            infrared tripleo-overcloud -vvv --version {{ osp_release }} --deployment-timeout {{ deployment_timeout | default(240) }} --build {{ osp_puddle }}  --deployment-files {{ nic_configs }} --introspect no --tagging no --deploy yes --controller-nodes {{ controller_count }} --compute-nodes {{ compute_count }} --storage-nodes {{ ceph_node_count }} {{ oc_extra_templates }} --network-protocol ipv4 --network-backend {{ network_backend }} {{ network_type }} true {{ ceph_params | default('') }} {{ storage_protocol_backend | default('') }} --public-network false {{ oc_heat_configs | default('') }} {{ oc_config_resource | default('') }} > {{ log_directory }}/overcloud_deploy.log 2>&1
         args:
             chdir: "{{ infrared_dir }}"

--- a/templates/ceph-storage.yaml.j2
+++ b/templates/ceph-storage.yaml.j2
@@ -33,6 +33,12 @@ parameters:
     default: ''
     description: IP address/subnet on the management network
     type: string
+{% if manila_enabled %}
+  StorageNFSIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage network
+    type: string
+{% endif %}
   ExternalNetworkVlanID:
     default: 10
     description: Vlan ID for the external network traffic.
@@ -53,6 +59,12 @@ parameters:
     default: 50
     description: Vlan ID for the tenant network traffic.
     type: number
+{% if manila_enabled %}
+  StorageNFSNetworkVlanID:
+    default: 70
+    description: Vlan ID for the storage network traffic.
+    type: number
+{% endif %}
   ExternalInterfaceDefaultRoute:
     default: '10.0.0.1'
     description: default route for the external network
@@ -123,6 +135,14 @@ parameters:
       guaranteed to pass through the data path of the segments in the
       Management network.
     type: number
+{% if manila_enabled %}
+  StorageNFSMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      Storage NFS network.
+    type: number
+{% endif %}
 {%raw%}{% endif %}{%endraw%}
 
 {%raw%}{% if install.version|openstack_release >= 14 %}{%endraw%}
@@ -175,7 +195,18 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+{% if manila_enabled %}
+  StorageNFSInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storageNFS network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+{% endif %}
 {%raw%}{% endif %}{%endraw%}
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig

--- a/templates/compute.yaml.j2
+++ b/templates/compute.yaml.j2
@@ -32,6 +32,12 @@ parameters:
     default: ''
     description: IP address/subnet on the management network
     type: string
+{% if manila_enabled %}
+  StorageNFSIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage network
+    type: string
+{% endif %}
   InternalApiNetworkVlanID:
     default: 20
     description: Vlan ID for the internal_api network traffic.
@@ -44,6 +50,12 @@ parameters:
     default: 50
     description: Vlan ID for the tenant network traffic.
     type: number
+{% if manila_enabled %}
+  StorageNFSNetworkVlanID:
+    default: 70
+    description: Vlan ID for the storage network traffic.
+    type: number
+{% endif %}
   ControlPlaneSubnetCidr: # Override this via parameter_defaults
     default: '24'
     description: The subnet CIDR of the control plane network.
@@ -110,6 +122,14 @@ parameters:
       guaranteed to pass through the data path of the segments in the
       Management network.
     type: number
+{% if manila_enabled %}
+  StorageNFSMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      Storage NFS network.
+    type: number
+{% endif %}
 {%raw%}{% endif %}{%endraw%}
 
 {%raw%}{% if install.version|openstack_release >= 14 %}{%endraw%}
@@ -162,7 +182,18 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+{% if manila_enabled %}
+  StorageNFSInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storageNFS network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+{% endif %}
 {%raw%}{% endif %}{%endraw%}
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig

--- a/templates/controller.yaml.j2
+++ b/templates/controller.yaml.j2
@@ -33,6 +33,12 @@ parameters:
     default: ''
     description: IP address/subnet on the management network
     type: string
+{% if manila_enabled %}
+  StorageNFSIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage network
+    type: string
+{% endif %}
   ExternalNetworkVlanID:
     default: 10
     description: Vlan ID for the external network traffic.
@@ -53,6 +59,12 @@ parameters:
     default: 50
     description: Vlan ID for the tenant network traffic.
     type: number
+{% if manila_enabled %}
+  StorageNFSNetworkVlanID:
+    default: 70
+    description: Vlan ID for the storage network traffic.
+    type: number
+{% endif %}
   ExternalInterfaceDefaultRoute:
     default: '10.0.0.1'
     description: default route for the external network
@@ -123,6 +135,14 @@ parameters:
       guaranteed to pass through the data path of the segments in the
       Management network.
     type: number
+{% if manila_enabled %}
+  StorageNFSMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the
+      Storage NFS network.
+    type: number
+{% endif %}
 {%raw%}{% endif %}{%endraw%}
 
 {%raw%}{% if install.version|openstack_release >= 14 %}{%endraw%}
@@ -175,7 +195,18 @@ parameters:
       Unless the default is changed, the parameter is automatically resolved
       from the subnet host_routes attribute.
     type: json
+{% if manila_enabled %}
+  StorageNFSInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storageNFS network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+{% endif %}
 {%raw%}{% endif %}{%endraw%}
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -307,6 +338,18 @@ resources:
                               -
                                 ip_netmask:
                                     get_param: StorageMgmtIpSubnet
+{% if manila_enabled %}
+                            -
+                              type: vlan
+                              vlan_id:
+                                  get_param: StorageNFSNetworkVlanID
+                              addresses:
+                              -
+                                ip_netmask:
+                                    get_param: StorageNFSIpSubnet
+{% endif %}
+
+
 {% if tenant_interface is defined and vlan_provider_network == false %}
                         -
                           type: ovs_bridge

--- a/templates/network-environment.yaml.j2
+++ b/templates/network-environment.yaml.j2
@@ -19,7 +19,13 @@ resource_registry:
 {% else %}
   OS::TripleO::Compute::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/compute.yaml
 {% endif %}
+
+{% if manila_enabled %}
+  OS::TripleO::ControllerStorageNfs::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/controller.yaml
+{% else %}
   OS::TripleO::Controller::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/controller.yaml
+{% endif %}
+
 {% if ceph_enabled %}
   OS::TripleO::CephStorage::Net::SoftwareConfig: vlans/{%raw%}{{ nics_subfolder }}{%endraw%}/ceph-storage.yaml
 {% endif %}
@@ -49,6 +55,16 @@ parameter_defaults:
     TenantAllocationPools: [{'start': '{{ tenant_allocation_pools_start }}', 'end': '{{ tenant_allocation_pools_end }}'}]
     TenantNetworkVlanID: {{ tenant_network_vlan_id }}
 {%raw%}{% endif %}{%endraw%}
+
+{% if manila_enabled %}
+
+    StorageNFSNetCidr: {{ storage_nfs_net_cidr }}
+    StorageNFSNetworkVlanID: {{ storage_nfs_network_vlan_id }}
+    StorageNFSAllocationPools: [{'start': '{{ storage_nfs_allocation_pools_start }}', 'end': '{{ storage_nfs_allocation_pools_end }}'}]
+
+    NeutronBridgeMappings: datacentre:br-ex,storage:br-isolated
+    NeutronNetworkVLANRanges: datacentre:1:1000,storage:300:1500
+{% endif %}
 
     DnsServers: ['{{ gateway }}']
     EC2MetadataIp: {{ gateway }}

--- a/templates/nodes_data.yml.j2
+++ b/templates/nodes_data.yml.j2
@@ -1,6 +1,11 @@
 ---
 parameter_defaults:
+{% if manila_enabled %}
+  ControllerStorageNfsCount: {{ controller_count }}
+{% else %}
   ControllerCount: {{ controller_count }}
+{% endif %}
+
 {% if failed_nodes_machine_type is not defined %}
 {% for node_type in machine_types %}
 {% if (node_type|string() == controller_machine_type|string()) and (node_type|string() == ceph_machine_type|string()) %}


### PR DESCRIPTION
To deploy overcloud with manila enabled the following params in group_vars/all.yml
- composable_roles: true
- ceph_machine_type:  '<ceph_machine_type>'
- ceph_enabled: true
- ceph_ifaces: <ceph_ifaces>
- manila_enabled: true