### PR TITLE
Enable scale in of compute nodes

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -223,7 +223,14 @@ browbeat: true
 #For Nova-less provisioning enable the variable
 novaless_prov: false
 
+# For node Scale Out.
 new_nodes_instack: "{{ playbook_dir }}/newnodes.json"
+
+# This file acts as a placeholder for node uuids, that needs to be scaled
+# in. Enable this variable and specify the node uuids in the specified file. 
+# The node scale in functionality is available for Compute nodes.
+nodes_tobescaledin: "{{ playbook_dir }}/scalein_nodes.yml"
+
 
 # This feature creates VMs on hypervisors and uses them as overcloud
 # compute nodes to simulate overcloud scale deployment. This feature

--- a/scalein.yml
+++ b/scalein.yml
@@ -1,0 +1,52 @@
+---
+- hosts: localhost
+  tasks:
+    - name: load instackenv
+      include_tasks: tasks/load_instackenv.yml
+
+    - name: get intrepeter
+      include_tasks: tasks/get_interpreter.yml
+      vars:
+        hostname: "{{ undercloud_hostname }}"
+        user: "stack"
+
+    - name: add undercloud
+      add_host:
+        name: "undercloud"
+        ansible_host: "{{ undercloud_hostname }}"
+        ansible_user: "stack"
+        ansible_python_interpreter: "{{ python_interpreter }}"
+
+
+- hosts: undercloud
+  vars:
+    ucscalein_nodes: /home/stack/scalein_nodes.yml
+  tasks:
+    - name: get the node uuids to be scaled in
+      copy:
+        src: "{{ nodes_tobescaledin }}"
+        dest: "{{ ucscalein_nodes }}"
+        force: yes
+
+    - name: delete the mentioned node(s)
+      shell: |
+        source /home/stack/stackrc
+        cat {{ ucscalein_nodes }} | awk '( NR>2 ) {print substr($0,3)}' | tr "\n" " " | xargs openstack overcloud node delete -y
+      when: nodes_tobescaledin is defined
+ 
+    - name: get all nodes count
+      shell: |
+        source /home/stack/stackrc
+        openstack server list -c ID -f value
+      register: all_nodes
+
+    - name: set fact compute count
+      set_fact:
+        compute_node_count: "{{ all_nodes.stdout_lines|length - controller_count - ceph_node_count }}"
+
+    - name: change compute count
+      lineinfile:
+        path: /home/stack/virt/nodes_data.yaml
+        regexp: 'ComputeCount:'
+        line: '    ComputeCount: {{ compute_node_count }}'
+


### PR DESCRIPTION
Using scalein.yml playbook compute nodes can now be scaled in.
Specify the node uuids which needs to be scaled in, through a file.

Signed-off-by: Ketan Mehta <kmehta@redhat.com>