### PR TITLE
create default share type and manila network

### DIFF
--- a/post.yml
+++ b/post.yml
@@ -61,3 +61,10 @@
       changed_when: false
       ignore_errors: true
 
+    - name: run post overcloud deploy
+      vars:
+        share_type_name: default
+        allocation_pool_start: "{{ storage_nfs_allocation_pools_start.split('.')[0:3] | join('.')  }}.150"
+        allocation_pool_end: "{{ storage_nfs_allocation_pools_end.split('.')[0:3] | join('.')  }}.250"
+      include_tasks: tasks/manila.yml
+      when: manila_enabled

--- a/tasks/manila.yml
+++ b/tasks/manila.yml
@@ -1,0 +1,15 @@
+---
+- name: create manila default share type
+  shell: |
+    source /home/stack/overcloudrc
+    manila type-create {{ share_type_name }} False
+
+- name: create StorageNFS network
+  shell: |
+    source /home/stack/overcloudrc
+    openstack network create StorageNFS --share  --provider-network-type vlan --provider-physical-network storage --provider-segment {{ storage_nfs_network_vlan_id }}
+
+- name: Create StorageNFSSubnet subnet
+  shell: |
+    source /home/stack/overcloudrc
+    openstack subnet create --allocation-pool start={{ allocation_pool_start }},end={{ allocation_pool_end }} --dhcp --network StorageNFS --subnet-range {{ storage_nfs_net_cidr }} StorageNFSSubnet


### PR DESCRIPTION
This PR adds support for creating a default share type
and StorageNFS network post-deploy.
 For CephFS-NFS scenario tests, we need to create a shared network mapping
to the underlying VLAN network on the overcloud.