### PR TITLE
Add python script to generate ansible inventory

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,7 +15,7 @@ Example:
 
 ### generate_ansible_inventory.py
 
-This script generates an ansible inventory files from overcloud-node-deployed.yaml. This script can be run after overcloud node provisioning or after overcloud deployment.
+This script generates an ansible inventory file from overcloud-node-deployed.yaml. This script can be run after overcloud node provisioning or after overcloud deployment.
 
 Usage:
   python3 generate_ansible_inventory.py -i (hosts group, Eg.: controller) -f (path to overcloud node deployed file) -o (path to directory to store ansible inventory file)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,4 +18,4 @@ Example:
 This script generates an ansible inventory files from overcloud-node-deployed.yaml. This script can be run after overcloud node provisioning or after overcloud deployment.
 
 Usage:
-  python3 generate_ansible_inventory.py -i <hosts group, Eg.: controller> -f <path to overcloud node deployed file> -o <path to directory to store ansible   inventory file>
+  python3 generate_ansible_inventory.py -i <hosts group, Eg.: controller> -f <path to overcloud node deployed file> -o <path to directory to store ansible inventory file>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,4 +18,4 @@ Example:
 This script generates an ansible inventory files from overcloud-node-deployed.yaml. This script can be run after overcloud node provisioning or after overcloud deployment.
 
 Usage:
-  python3 generate_ansible_inventory.py -i <hosts group, Eg.: controller> -f <path to overcloud node deployed file> -o <path to directory to store ansible inventory file>
+  python3 generate_ansible_inventory.py -i (hosts group, Eg.: controller) -f (path to overcloud node deployed file) -o (path to directory to store ansible inventory file)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,5 +18,4 @@ Example:
 This script generates an ansible inventory files from overcloud-node-deployed.yaml. This script can be run after overcloud node provisioning or after overcloud deployment.
 
 Usage:
-  python3 generate_ansible_inventory.py -i <hosts group, Eg.: controller> -f <path to overcloud node deployed file> \
-  -o <path to directory to store ansible   inventory file>
+  python3 generate_ansible_inventory.py -i <hosts group, Eg.: controller> -f <path to overcloud node deployed file> -o <path to directory to store ansible   inventory file>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,3 +12,11 @@ this script is used for deploying all-in-one OSP16.1 environment
 
 Example:
   ./infrared_osp16_1.sh <hostname> full
+
+### generate_ansible_inventory.py
+
+This script generates an ansible inventory files from overcloud-node-deployed.yaml. This script can be run after overcloud node provisioning or after overcloud deployment.
+
+Usage:
+  python3 generate_ansible_inventory.py -i <hosts group, Eg.: controller> -f <path to overcloud node deployed file> \
+  -o <path to directory to store ansible   inventory file>

--- a/scripts/generate_ansible_inventory.py
+++ b/scripts/generate_ansible_inventory.py
@@ -1,4 +1,4 @@
-# This script generates an ansible inventory files from
+# This script generates an ansible inventory file from
 # overcloud-node-deployed.yaml.
 # This script can be run after overcloud node provisioning
 # or after overcloud deployment.

--- a/scripts/generate_ansible_inventory.py
+++ b/scripts/generate_ansible_inventory.py
@@ -1,0 +1,64 @@
+# This script generates an ansible inventory files from
+# overcloud-node-deployed.yaml.
+# This script can be run after overcloud node provisioning
+# or after overcloud deployment.
+#
+# Usage :
+# python3 generate_ansible_inventory.py -i <hosts group, Eg.: controller> \
+# -f <path to overcloud node deployed file> \
+# -o <path to directory to store ansible inventory file>
+
+import yaml
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-i",
+    "--hosts_group",
+    help="Group of hosts to generate inventory file(Eg.: controller)",
+    nargs="?",
+    required=True,
+    dest="hostsgroup")
+parser.add_argument(
+    "-f",
+    "--overcloud-node-deployed-file-path",
+    help="Path to overcloud-node-deployed.yaml file",
+    nargs="?",
+    required=True,
+    dest="overcloudnodedeployedfilepath",
+)
+parser.add_argument(
+    "-o",
+    "--hostsfiledir",
+    help="Directory to write hosts file",
+    nargs="?",
+    required=True,
+    dest="hostsfiledir",
+)
+
+with open(parser.parse_args().overcloudnodedeployedfilepath, "r") as f:
+    dict = yaml.load(f)
+
+hostsgroup = parser.parse_args().hostsgroup
+ips = []
+if hostsgroup == "overcloud":
+    for i in dict["parameter_defaults"]["DeployedServerPortMap"]:
+        ips.append(
+            dict["parameter_defaults"]["DeployedServerPortMap"][i][
+                "fixed_ips"][0]["ip_address"])
+else:
+    for i in dict["parameter_defaults"]["DeployedServerPortMap"]:
+        if hostsgroup in i:
+            ips.append(
+                dict["parameter_defaults"]["DeployedServerPortMap"][i][
+                    "fixed_ips"][0]["ip_address"])
+
+with open("{}/{}_hosts_ips".format(parser.parse_args().hostsfiledir,
+                                   hostsgroup), "w") as f2:
+    print("[{}]".format(hostsgroup), file=f2)
+    for i in ips:
+        print(i, file=f2)
+    print("\n", file=f2, end="")
+    print("[all:vars]", "ansible_connection=ssh", "ansible_user=heat-admin",
+          "ansible_ssh_common_args='-o StrictHostKeyChecking=no'", sep="\n",
+          file=f2)


### PR DESCRIPTION
This PR adds a python script to generate ansible inventory for all overcloud hosts, or a subset of hosts, like controller or compute. This script can be run after overcloud node provisioning also, unlike tripleo-ansible-inventory which requires the overcloudrc file to be present. An example usage of this script is mentioned below.
python3 generate_ansible_inventory.py -i controller -f /home/stack/templates-output/overcloud-node-deployed.yaml -o /home/stack/custom_playbooks
This will create an ansible hosts inventory file "controller_hosts_ips" in the directory /home/stack/custom_playbooks with the controller host ctlplane IPs.
This PR has been tested for OSP 17, but should work for other versions too.