### PR TITLE
Updated the image used by jetpack/hammer/Dockerfile

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -5,9 +5,7 @@
         include_tasks: tasks/load_instackenv.yml
 
       - name: get tn10rt machines list
-        get_url:
-          url: http://wiki.scalelab.redhat.com/1029u/
-          dest: ~/tn10rt.html
+        shell: curl http://wiki.scalelab.redhat.com/1029u/ > ~/tn10rt.html
 
       - name: load tn10rt machines list
         set_fact:

--- a/hammer/Dockerfile
+++ b/hammer/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM quay.io/centos/centos:stream8
 
 ARG foreman_url=https://foreman.example.com
 


### PR DESCRIPTION
i have recently faced issues with image used in jetpack/hammer/Dockerfile and 'get tn10rt machines list' ansible task. This PR is a workaround for those issues.