### PR TITLE
fix issues with tn10rt.html file

### DIFF
--- a/cleanup.yml
+++ b/cleanup.yml
@@ -28,3 +28,7 @@
         file:
             path: "{{ ansible_user_dir }}/undercloud.conf"
             state: absent
+      - name: Remove tn10rt.html
+        file:
+            path: "{{ ansible_user_dir }}/tn10rt.html"
+            state: absent

--- a/common.yml
+++ b/common.yml
@@ -5,9 +5,7 @@
         include_tasks: tasks/load_instackenv.yml
 
       - name: get tn10rt machines list
-        get_url:
-          url: http://wiki.scalelab.redhat.com/1029u/
-          dest: ~/tn10rt.html
+        shell: curl http://wiki.scalelab.redhat.com/1029u/ > ~/tn10rt.html
 
       - name: load tn10rt machines list
         set_fact:


### PR DESCRIPTION
ansible 'get_url' module sometime fails to download tn10rt.html file
so using 'shell' moduel instead. Also added the tn10rt.html as a part
of the cleanup.