### PR TITLE
Add multiple  NtpServers

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -54,5 +54,5 @@
 
       - name: use rdu2.redhat.com time servers for Scale Lab in Raleigh NC USA
         set_fact:
-          time_servers: ["clock1.rdu2.redhat.com"]
+          time_servers: ["clock1.rdu2.redhat.com", "clock.redhat.com"]
         when: lab_name == "scale"


### PR DESCRIPTION
Having only a single timesource can lead to deployment failures
if the time source is unavailable during the deployment