### PR TITLE
Add support for badfish parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Note: User can add support for fc640 in case your allocation has machines with s
 * Python 3.6+
 * > RHEL 7.7 for ansible jump host
 * A host for running hammer cli/ipmitool/badfish operations referenced by the variable *hammer_host*
-* Passwordless sudo for user running the playbook on the ansible control node (host where the playbooks are being run from)
+* SELinux mode as Permissive on the ansible control node (host where the playbooks are being run from)
+* Passwordless sudo for user running the playbook on the ansible control node
 
 Passwordless sudo can be setup as below:
 

--- a/badfish/Dockerfile
+++ b/badfish/Dockerfile
@@ -1,0 +1,2 @@
+FROM quay.io/quads/badfish
+COPY dell-hosts /

--- a/badfish/Dockerfile
+++ b/badfish/Dockerfile
@@ -1,2 +1,0 @@
-FROM quay.io/quads/badfish
-COPY dell-hosts /

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -60,3 +60,4 @@
       - name: pull badfish image
         become: yes
         shell: podman pull quay.io/quads/badfish
+        ignore_errors: yes

--- a/common.yml
+++ b/common.yml
@@ -65,6 +65,27 @@
         with_sequence: 0-{{ (oc_instackenv_content.nodes|length - 1) }}
         register: host_list
 
+      - name: remove existing dell-hosts file
+        file:
+            path: "~/jetpack/badfish/dell-hosts"
+            state: absent
+
+      - name: prepare dell hosts for badfish
+        shell: echo "mgmt-{{ item[1].stdout }}" >> ~/jetpack/badfish/dell-hosts
+        when: vendors is defined and item[0] == "dell"
+        with_together:
+          - "{{ vendors }}"
+          - "{{ host_list.results }}"
+
+      - name: remove existing badfish image
+        shell: podman rmi -f quay.io/quads/badfish
+        become: yes
+        ignore_errors: yes
+
+      - name: build badfish image
+        shell: podman build --tag badfish:latest -f ~/jetpack/badfish/Dockerfile
+        become: yes
+
       - include_tasks: tasks/get_interpreter.yml
         vars:
           hostname: "{{ undercloud_hostname }}"

--- a/common.yml
+++ b/common.yml
@@ -65,26 +65,15 @@
         with_sequence: 0-{{ (oc_instackenv_content.nodes|length - 1) }}
         register: host_list
 
-      - name: remove existing dell-hosts file
-        file:
-            path: "~/jetpack/badfish/dell-hosts"
-            state: absent
+      - name: clear existing dell-hosts file
+        shell: echo "" > {{ playbook_dir }}/badfish/dell-hosts
 
       - name: prepare dell hosts for badfish
-        shell: echo "mgmt-{{ item[1].stdout }}" >> ~/jetpack/badfish/dell-hosts
+        shell: echo "mgmt-{{ item[1].stdout }}" >> {{ playbook_dir }}/badfish/dell-hosts
         when: vendors is defined and item[0] == "dell"
         with_together:
           - "{{ vendors }}"
           - "{{ host_list.results }}"
-
-      - name: remove existing badfish image
-        shell: podman rmi -f quay.io/quads/badfish
-        become: yes
-        ignore_errors: yes
-
-      - name: build badfish image
-        shell: podman build --tag badfish:latest -f ~/jetpack/badfish/Dockerfile
-        become: yes
 
       - include_tasks: tasks/get_interpreter.yml
         vars:

--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -34,7 +34,7 @@
 
         - name: Wait for iDrac to be responsive
           become: yes
-          shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
+          shell: podman run -it -v {{ playbook_dir }}/badfish:/dell --rm quay.io/quads/badfish --host-list /dell/dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
           register: wait_for_idrac
           until: wait_for_idrac is succeeded
           retries: 20

--- a/setup_undercloud.yml
+++ b/setup_undercloud.yml
@@ -34,11 +34,7 @@
 
         - name: Wait for iDrac to be responsive
           become: yes
-          shell: podman run -it --rm quay.io/quads/badfish -H mgmt-{{ item[1].stdout }} -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
-          when: vendors is defined and item[0] == "dell"
-          with_together:
-            - "{{ vendors }}"
-            - "{{ host_list.results }}"
+          shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
           register: wait_for_idrac
           until: wait_for_idrac is succeeded
           retries: 20

--- a/tasks/set_boot_order_director.yml
+++ b/tasks/set_boot_order_director.yml
@@ -1,7 +1,7 @@
 ---
 - name: Clear redfish job queues
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} --clear-jobs --force
+  shell: podman run -it -v {{ playbook_dir }}/badfish:/dell --rm quay.io/quads/badfish --host-list /dell/dell-hosts -u quads -p {{ chassis_password }} --clear-jobs --force
   register: clear_jobs
   until: clear_jobs is succeeded
   retries: 3
@@ -9,7 +9,7 @@
 
 - name: Wait for iDrac to be responsive
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
+  shell: podman run -it -v {{ playbook_dir }}/badfish:/dell --rm quay.io/quads/badfish --host-list /dell/dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
   register: wait_for_idrac
   until: wait_for_idrac is succeeded
   retries: 20
@@ -17,7 +17,7 @@
 
 - name: set boot order director (badfish)
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml -t director
+  shell: podman run -it -v {{ playbook_dir }}/badfish:/dell --rm quay.io/quads/badfish --host-list /dell/dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml -t director
   retries: 5
   delay: 3
   register: result
@@ -25,11 +25,11 @@
 
 - name: power cycle overcloud nodes
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} --power-cycle
+  shell: podman run -it -v {{ playbook_dir }}/badfish:/dell --rm quay.io/quads/badfish --host-list /dell/dell-hosts -u quads -p {{ chassis_password }} --power-cycle
 
 - name: Wait for iDrac to be responsive
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
+  shell: podman run -it -v {{ playbook_dir }}/badfish:/dell --rm quay.io/quads/badfish --host-list /dell/dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
   register: wait_for_idrac
   until: wait_for_idrac is succeeded
   retries: 20

--- a/tasks/set_boot_order_director.yml
+++ b/tasks/set_boot_order_director.yml
@@ -1,11 +1,7 @@
 ---
 - name: Clear redfish job queues
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish -H mgmt-{{ item[1].stdout }} -u quads -p {{ chassis_password }} --clear-jobs --force
-  when: vendors is defined and item[0] == "dell"
-  with_together:
-    - "{{ vendors }}"
-    - "{{ host_list.results }}"
+  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} --clear-jobs --force
   register: clear_jobs
   until: clear_jobs is succeeded
   retries: 3
@@ -13,11 +9,7 @@
 
 - name: Wait for iDrac to be responsive
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish -H mgmt-{{ item[1].stdout }} -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
-  when: vendors is defined and item[0] == "dell"
-  with_together:
-    - "{{ vendors }}"
-    - "{{ host_list.results }}"
+  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
   register: wait_for_idrac
   until: wait_for_idrac is succeeded
   retries: 20
@@ -25,11 +17,7 @@
 
 - name: set boot order director (badfish)
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish -H mgmt-{{ item[1].stdout }} -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml -t director
-  when: vendors is defined and item[0] == "dell"
-  with_together:
-    - "{{ vendors }}"
-    - "{{ host_list.results }}"
+  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml -t director
   retries: 5
   delay: 3
   register: result
@@ -37,19 +25,11 @@
 
 - name: power cycle overcloud nodes
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish -H mgmt-{{ item[1].stdout }} -u quads -p {{ chassis_password }} --power-cycle
-  when: vendors is defined and item[0] == "dell"
-  with_together:
-    - "{{ vendors }}"
-    - "{{ host_list.results }}"
+  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} --power-cycle
 
 - name: Wait for iDrac to be responsive
   become: yes
-  shell: podman run -it --rm quay.io/quads/badfish -H mgmt-{{ item[1].stdout }} -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
-  when: vendors is defined and item[0] == "dell"
-  with_together:
-    - "{{ vendors }}"
-    - "{{ host_list.results }}"
+  shell: podman run -it --rm quay.io/quads/badfish --host-list /dell-hosts -u quads -p {{ chassis_password }} -i config/idrac_interfaces.yml --check-boot
   register: wait_for_idrac
   until: wait_for_idrac is succeeded
   retries: 20


### PR DESCRIPTION
when we have list of baremetal systems to be managed by badfish,
it can take list of all baremetal nodes at once and operate on each simultaneously