### PR TITLE
Increase OCP ClusterNetwork cidr range

### DIFF
--- a/templates/install-config.yaml.j2
+++ b/templates/install-config.yaml.j2
@@ -25,7 +25,7 @@ metadata:
   name: "{{ ocp_cluster_name }}"
 networking:
   clusterNetwork:
-  - cidr: 10.128.0.0/14
+  - cidr: 10.128.0.0/13
     hostPrefix: 22
   serviceCIDR: 172.30.0.0/16
   machineCIDR: 10.0.0.0/16


### PR DESCRIPTION
For installing OCP clusters with large number of worker nodes, the CIDR range for the cluster network has to be changed from /14 to /13.