### PR TITLE
Composable roles: Fix the node count when nodes fails introspection

### DIFF
--- a/composable.yml
+++ b/composable.yml
@@ -101,8 +101,3 @@
         openstack overcloud roles generate -o ~/roles_data.yaml --roles-path ~/roles {{ roles }}
       args:
         chdir: "/home/stack"
-
-    - name: setting node capabilities (boot_mode bios)
-      vars:
-        boot_mode: bios
-      include_tasks: tasks/set_boot_mode.yml

--- a/introspect.yml
+++ b/introspect.yml
@@ -34,11 +34,3 @@
             changed_when: false
             ignore_errors: true
         when: scale_compute_vms == true
-
-- hosts: undercloud
-  vars:
-      tn10rt: "{{ hostvars['localhost']['tn10rt'] }}"
-  tasks:
-      - name: check and delete introspection failed nodes
-        include_tasks: tasks/delete_introspection_failed_nodes.yml
-        when: scale_compute_vms == false

--- a/main.yml
+++ b/main.yml
@@ -30,6 +30,7 @@
 - import_playbook: composable_prepare_nic_configs.yml
   tags:
     - undercloud
+    - introspect
     - overcloud
   when: composable_roles
 
@@ -43,7 +44,7 @@
 
 - import_playbook: post_introspect.yml
   tags:
-    - overcloud
+    - introspect
 
 - import_playbook: tag.yml
   tags:

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -45,79 +45,23 @@
         dest: "/home/stack/wipe-disk.sh"
       when: ceph_enabled and (clean_nodes != true)
 
-    - name: setting node capabilities (boot_mode bios)
-      vars:
-        boot_mode: bios
-      include_tasks: tasks/set_boot_mode.yml
-      when: osp_release|int == 17
-
-    - name: get overcloud node images
-      vars:
-        image_path: /home/stack/images
-      include_tasks: tasks/overcloud_images.yaml
-      when: osp_release|int == 17
-
-    - name: Set name for overcloud nodes
-      shell: |
-        source ~/stackrc
-        openstack baremetal node list --fields uuid driver_info -f table | grep ipmi | sed -e "s/u'/'/g" -e "s/'/\\\\\"/g" \
-        | awk -F\| '  driver_info = $3   { system(  "name=$(echo  " driver_info " |jq .ipmi_address) ;\
-        openstack baremetal node set --name $name " $2) }  '
+    - name: remove the templates dir
+      file:
+        state: absent
+        path: /home/stack/templates
+      ignore_errors: true
 
 - hosts: localhost
   gather_facts: yes
   tasks:
-      - name: Set compute count fact
-        set_fact:
-          compute_count: "{{ compute_count|default(oc_instackenv_content.nodes|length - (controller_count|int) - (ceph_node_count|int)) }}"
-
-      - name: get nodes
+      - name: get compute count
         shell: |
-            source ~/stackrc
-            openstack baremetal node list -f value -c UUID
-        register: nodes_uuids
-        changed_when: false
-        delegate_to: "{{ groups.undercloud|first }}"
-        vars:
-          ansible_python_interpreter: "{{ python_interpreter }}"
-          ansible_user: "stack"
+          cat compute_count
+        register: compute_count
 
-      - block:
-        - name: check registered nodes with requested node count
-          debug:
-            msg: "Less nodes {{ nodes_uuids.stdout_lines|length }} registered with ironic than requested {{ compute_count|int + controller_count|int + ceph_node_count|int }}. So we will be adjusting controller and compute count according to registered available nodes"
-          when: nodes_uuids.stdout_lines|length < (compute_count|int + controller_count|int + ceph_node_count|int)
-
-        - name: Adjust compute count
-          set_fact:
-            compute_count: "{{ compute_count|int - 1 }}"
-          when: nodes_uuids.stdout_lines|length < (compute_count|int + controller_count|int + ceph_node_count|int)
-          with_items: "{{ nodes_uuids }}"
-        when: scale_compute_vms == false
-
-      - name: fail when compute count is less than 1
-        fail:
-            msg: "Failing as compute count is less than 1"
-        when: compute_count|int < 1
-
-      - name: prepare baremetal_deployment.yaml.j2
-        template:
-          src: baremetal_deployment.yaml.j2
-          dest: "{{ ansible_user_dir }}/virt/network/baremetal_deployment.yaml.j2"
-        when: osp_release|int == 17
-
-      - name: set facts about failed nodes
+      - name: set fact compute count
         set_fact:
-          failed_nodes_machine_type: "{{  hostvars['undercloud']['failed_nodes_machine_type'] }}"
-          failed_nodes_machine_count: "{{ hostvars['undercloud']['failed_nodes_machine_count'] }}"
-        when: composable_roles
-        ignore_errors: true
-
-      - name: Template out nodes_data file
-        template:
-          src: nodes_data.yml.j2
-          dest: ~/virt/nodes_data.yaml
-        when: composable_roles
+          compute_count: "{{ compute_count.stdout|int }}"
 
       - name: set nvme parameter_defaults
         vars:
@@ -303,18 +247,6 @@
           - name: provisioning baremetal nodes
             include_tasks: tasks/provisioning_baremetal_nodes.yml
         when: novaless_prov
-
-      - name: set fact for storage nodes
-        set_fact:
-          storage_node_disks: "{{ hostvars['undercloud']['storage_node_disks']|unique }}"
-        when: ceph_enabled and storage_node_disks is not defined
-
-      - name: generate internal.yml.j2
-        template:
-          src: internal.yml.j2
-          dest: ~/.infrared/plugins/tripleo-overcloud/templates/storage/internal.yml.j2
-          force: yes
-        when: ceph_enabled
 
       - name: set facts for ceph deployment
         set_fact:

--- a/post_introspect.yml
+++ b/post_introspect.yml
@@ -1,6 +1,12 @@
 ---
 - hosts: undercloud
+  vars:
+      tn10rt: "{{ hostvars['localhost']['tn10rt'] }}"
   tasks:
+    - name: check and delete introspection failed nodes
+      include_tasks: tasks/delete_introspection_failed_nodes.yml
+      when: scale_compute_vms == false
+
     - name: get all nodes
       shell: |
         source ~/stackrc
@@ -32,6 +38,7 @@
               fi
             done
           register: storage_disks_info_comp
+
           with_items: "{{ total_nodes.stdout_lines | default([]) }}"
           when: composable_roles
 
@@ -53,8 +60,83 @@
         msg: "{{ storage_node_disks|unique }}"
       when: ceph_enabled
 
-    - name: remove the templates dir
-      file:
-        state: absent
-        path: /home/stack/templates
-      ignore_errors: true
+    - name: setting node capabilities (boot_mode bios)
+      vars:
+        boot_mode: bios
+      include_tasks: tasks/set_boot_mode.yml
+      when: osp_release|int >= 17 or composable_roles
+
+    - name: get overcloud node images
+      vars:
+        image_path: /home/stack/images
+      include_tasks: tasks/overcloud_images.yaml
+      when: osp_release|int == 17
+
+    - name: Set name for overcloud nodes
+      shell: |
+        source ~/stackrc
+        openstack baremetal node list --fields uuid driver_info -f table | grep ipmi | sed -e "s/u'/'/g" -e "s/'/\\\\\"/g" \
+        | awk -F\| '  driver_info = $3   { system(  "name=$(echo  " driver_info " |jq .ipmi_address) ;\
+        openstack baremetal node set --name $name " $2) }  '
+
+- hosts: localhost
+  gather_facts: yes
+  vars:
+    nodes_uuids: "{{ hostvars['undercloud']['total_nodes'] }}"
+  tasks:
+      - name: Set compute count fact
+        set_fact:
+          compute_count: "{{ compute_count|default(oc_instackenv_content.nodes|length - (controller_count|int) - (ceph_node_count|int)) }}"
+
+      - block:
+        - name: check registered nodes with requested node count
+          debug:
+            msg: "Less nodes {{ nodes_uuids.stdout_lines|length }} registered with ironic than requested {{ compute_count|int + controller_count|int + ceph_node_count|int }}. So we will be adjusting controller and compute count according to registered available nodes"
+          when: nodes_uuids.stdout_lines|length < (compute_count|int + controller_count|int + ceph_node_count|int)
+
+        - name: Adjust compute count
+          set_fact:
+            compute_count: "{{ compute_count|int - 1 }}"
+          when: nodes_uuids.stdout_lines|length < (compute_count|int + controller_count|int + ceph_node_count|int)
+          with_items: "{{ nodes_uuids }}"
+        when: scale_compute_vms == false
+
+      - name: save the compute count
+        shell: |
+           echo "{{ compute_count }}" > compute_count
+
+      - name: fail when compute count is less than 1
+        fail:
+            msg: "Failing as compute count is less than 1"
+        when: compute_count|int < 1
+
+      - name: set facts about failed nodes
+        set_fact:
+          failed_nodes_machine_type: "{{  hostvars['undercloud']['failed_nodes_machine_type'] }}"
+          failed_nodes_machine_count: "{{ hostvars['undercloud']['failed_nodes_machine_count'] }}"
+        when: composable_roles
+        ignore_errors: true
+
+      - name: prepare baremetal_deployment.yaml.j2
+        template:
+          src: baremetal_deployment.yaml.j2
+          dest: "{{ ansible_user_dir }}/virt/network/baremetal_deployment.yaml.j2"
+        when: osp_release|int == 17
+
+      - name: Template out nodes_data file
+        template:
+          src: nodes_data.yml.j2
+          dest: ~/virt/nodes_data.yaml
+        when: composable_roles
+
+      - name: set fact for storage nodes
+        set_fact:
+          storage_node_disks: "{{ hostvars['undercloud']['storage_node_disks']|unique }}"
+        when: ceph_enabled and storage_node_disks is not defined
+
+      - name: generate internal.yml.j2
+        template:
+          src: internal.yml.j2
+          dest: ~/.infrared/plugins/tripleo-overcloud/templates/storage/internal.yml.j2
+          force: yes
+        when: ceph_enabled

--- a/tasks/delete_introspection_failed_nodes.yml
+++ b/tasks/delete_introspection_failed_nodes.yml
@@ -43,14 +43,12 @@
   ignore_errors: yes
 
 # TODO for external labs
-
 - name: get the machine type of introspection failed nodes
   set_fact:
     failed_nodes_machine_type: "{{ failed_nodes_machine_type|default([]) + [(type != '1029u')|ternary(type, (item.stdout.replace('mgmt-', '').replace('\"', '') in tn10rt) | ternary('1029utn10rt', '1029utrtp')) ] }}"
   vars:
-      type: "{{ (lab_name == 'scale' | ternary(item.stdout.split('.')[0].split('-')[4], item.stdout.split('.')[0].split('-')[3])) }}"
+      type: "{{ (lab_name == 'scale') | ternary(item.stdout.split('.')[0].split('-')[4], item.stdout.split('.')[0].split('-')[3]) }}"
   with_items: "{{ failed_nodes_ipmi_addr.results }}"
-  when: lab_name in ['scale', 'alias']
 
 - name: set machine count of failed nodes
   set_fact:
@@ -64,7 +62,7 @@
 
 - name: print the machine count of failed nodes
   debug:
-    msg: "{{ failed_nodes_machine_count }}"
+    var: failed_nodes_machine_count
   when: failed_nodes_machine_type is defined
 
 - name: power off the failed nodes
@@ -75,31 +73,30 @@
   changed_when: false
   ignore_errors: true
 
-- name: delete failed nodes
+- name: move to manage and delete failed nodes
   shell: |
       source ~/stackrc
+      openstack baremetal node manage {{ item }}
       openstack baremetal node delete {{ item }}
   with_items: "{{ failed_nodes_uuids | default([]) }}"
   changed_when: false
   ignore_errors: true
 
-- name: get all nodes
+- name: get nodes in manageable state
   shell: |
       source ~/stackrc
-      openstack baremetal node list -f value -c UUID
-  register: total_nodes
+      openstack baremetal node list | grep -i manageable | cut -d "|" -f 2
+  register: manageable_nodes
   changed_when: false
 
 - name: set provision state of all nodes to available
   shell: |
       source ~/stackrc;
-      export PROV_STATE=$(openstack baremetal node show {{ item }} -c provision_state -f value);
-      if [[ $PROV_STATE != *"available"* ]]; then
-          openstack baremetal node provide {{ item }};
-      fi
-  with_items: "{{ total_nodes.stdout_lines | default([]) }}"
+      openstack baremetal node provide {{ item }};
+  with_items: "{{ manageable_nodes.stdout_lines | default([]) }}"
   changed_when: false
   register: prov_state
   until: prov_state is succeeded
   retries: 3
   delay: 30
+

--- a/tasks/set_root_hints.yml
+++ b/tasks/set_root_hints.yml
@@ -7,7 +7,7 @@
   with_items:
     - "{{ total_nodes.stdout_lines }}"
 
-- name: set root hints based on model (740XD G-CL)
+- name: set root hints based on model
   shell: |
     source ~/stackrc
     openstack baremetal node set "{{ item[0] }}" --property root_device='{"model": {{ item[1].stdout_lines[0] }} }'

--- a/templates/baremetal_deployment.yaml.j2
+++ b/templates/baremetal_deployment.yaml.j2
@@ -61,22 +61,10 @@
 {% endfor %}
 
 {% else %}
-{% for failed_machine_type in failed_nodes_machine_type|unique %}
 {% for node_type in machine_types %}
-{% if node_type|string() == failed_machine_type|string() %}
-
-{% if failed_machine_type|string() == controller_machine_type|string() %}
-  count: {{ machine_count[node_type]|int - controller_count|int - failed_nodes_machine_count[failed_machine_type]|int }}
-{% else %}
-  count: {{ machine_count[node_type]|int - failed_nodes_machine_count[failed_machine_type]|int }}
-{% endif %}
-
-{% elif node_type|string() == controller_machine_type|string() %}
-  count: {{ machine_count[node_type]|int - controller_count|int }}
-{% else %}
-  count: {{ machine_count[node_type] }}
-{% endif %}
-{% endfor %}
+{% if node_type in failed_nodes_machine_type|unique and node_type == controller_machine_type %}
+- name: Compute{{ node_type }}
+  count: {{ machine_count[node_type]|int - failed_nodes_machine_count[node_type] - controller_count|int }}
   hostname_format: compute{{ node_type}}-%index%
   defaults:
     profile: baremetal{{ node_type }}
@@ -89,6 +77,52 @@
     - network: internal_api
     - network: tenant
     - network: external
+{% elif node_type not in failed_nodes_machine_type|unique and node_type == controller_machine_type %}
+- name: Compute{{ node_type }}
+  count: {{ machine_count[node_type]|int - controller_count|int }}
+  hostname_format: compute{{ node_type}}-%index%
+  defaults:
+    profile: baremetal{{ node_type }}
+    network_config:
+      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
+    networks:
+    - network: ctlplane
+      vif: true
+    - network: storage
+    - network: internal_api
+    - network: tenant
+    - network: external
+{% elif node_type in failed_nodes_machine_type|unique %}
+- name: Compute{{ node_type }}
+  count: {{ machine_count[node_type]|int - failed_nodes_machine_count[node_type] }}
+  hostname_format: compute{{ node_type}}-%index%
+  defaults:
+    profile: baremetal{{ node_type }}
+    network_config:
+      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
+    networks:
+    - network: ctlplane
+      vif: true
+    - network: storage
+    - network: internal_api
+    - network: tenant
+    - network: external
+{% else %}
+- name: Compute{{ node_type }}
+  count: {{ machine_count[node_type]|int }}
+  hostname_format: compute{{ node_type}}-%index%
+  defaults:
+    profile: baremetal{{ node_type }}
+    network_config:
+      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
+    networks:
+    - network: ctlplane
+      vif: true
+    - network: storage
+    - network: internal_api
+    - network: tenant
+    - network: external
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endif %}
@@ -107,4 +141,3 @@
     - network: storage
     - network: storage_mgmt
 {% endif -%}
-


### PR DESCRIPTION
This PR fixes
failed_nodes_machine_type fact
Adjusts node count for computes after introspection fails
Optimize the code to run faster with overcloud tag