### PR TITLE
Extends default partitions for overcloud nodes

### DIFF
--- a/overcloud-node-growvols.yml
+++ b/overcloud-node-growvols.yml
@@ -1,0 +1,13 @@
+---
+- name: Specify extra vars for extending logical volumes
+  import_playbook: /usr/share/ansible/tripleo-playbooks/cli-overcloud-node-growvols.yaml
+  vars:
+    growvols_args: >
+        /=30GB
+        /tmp=5GB
+        /home=10GB
+        /var/log=10GB
+        /var/log/audit=1GB
+        /var=90%
+        /srv=10%
+

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -258,6 +258,16 @@
           deployment_timeout: 2400
         when: scale_compute_vms == true
 
+      - name: change the default values for overcloud-node-growvols
+        copy:
+          src: "overcloud-node-growvols.yml"
+          dest: "/home/stack/cli-overcloud-node-growvols.yml"
+        delegate_to: "{{ undercloud_hostname }}"
+        vars:
+          ansible_python_interpreter: "{{ python_interpreter }}"
+          ansible_user: "stack"
+        when: osp_release|int >= 17
+
       - name: run tripleo-overcloud deploy
         shell: |
             source .venv/bin/activate

--- a/templates/baremetal_deployment.yaml.j2
+++ b/templates/baremetal_deployment.yaml.j2
@@ -1,6 +1,8 @@
 - name: Controller
   count: {{ controller_count }}
   hostname_format: controller-%index%
+  ansible_playbooks:
+    - playbook: /home/stack/overcloud-node-growvols.yml
   defaults:
 {% if composable_roles %}
     profile: baremetal{{ controller_machine_type }}
@@ -18,10 +20,12 @@
     - network: tenant
     - network: external
 
-{% if  composable_roles == false %}
+{% if composable_roles == false %}
 - name: Compute
   count: {{ compute_count }}
   hostname_format: compute-%index%
+  ansible_playbooks:
+    - playbook: /home/stack/overcloud-node-growvols.yml
   defaults:
     network_config:
       template: /home/stack/virt/network/vlans/compute.j2
@@ -33,105 +37,61 @@
     - network: tenant
     - network: external
 {% endif %}
-
 {% if composable_roles %}
-{% if failed_nodes_machine_type is not defined %}
 {% for node_type in machine_types %}
+{% set compute_count = machine_count[node_type]|int %}
 
-- name: Compute{{ node_type }}
-{% if (node_type|string() == controller_machine_type|string()) and (node_type|string() == ceph_machine_type|string()) %}
-  count: {{ machine_count[node_type]|int - controller_count|int - ceph_node_count|int }}
-{% elif node_type|string() == controller_machine_type|string() %}
-  count: {{ machine_count[node_type]|int - controller_count|int }}
-{% else %}
-  count: {{ machine_count[node_type] }}
-{% endif %}
-  hostname_format: compute{{ node_type}}-%index%
-  defaults:
-    profile: baremetal{{ node_type }}
-    network_config:
-      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
-    networks:
-    - network: ctlplane
-      vif: true
-    - network: storage
-    - network: internal_api
-    - network: tenant
-    - network: external
-{% endfor %}
+{#- Reduce the failed_node_counts at the beginning -#}
 
-{% else %}
-{% for node_type in machine_types %}
-{% if node_type in failed_nodes_machine_type|unique and node_type == controller_machine_type %}
-- name: Compute{{ node_type }}
-  count: {{ machine_count[node_type]|int - failed_nodes_machine_count[node_type] - controller_count|int }}
-  hostname_format: compute{{ node_type}}-%index%
-  defaults:
-    profile: baremetal{{ node_type }}
-    network_config:
-      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
-    networks:
-    - network: ctlplane
-      vif: true
-    - network: storage
-    - network: internal_api
-    - network: tenant
-    - network: external
-{% elif node_type not in failed_nodes_machine_type|unique and node_type == controller_machine_type %}
-- name: Compute{{ node_type }}
-  count: {{ machine_count[node_type]|int - controller_count|int }}
-  hostname_format: compute{{ node_type}}-%index%
-  defaults:
-    profile: baremetal{{ node_type }}
-    network_config:
-      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
-    networks:
-    - network: ctlplane
-      vif: true
-    - network: storage
-    - network: internal_api
-    - network: tenant
-    - network: external
-{% elif node_type in failed_nodes_machine_type|unique %}
-- name: Compute{{ node_type }}
-  count: {{ machine_count[node_type]|int - failed_nodes_machine_count[node_type] }}
-  hostname_format: compute{{ node_type}}-%index%
-  defaults:
-    profile: baremetal{{ node_type }}
-    network_config:
-      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
-    networks:
-    - network: ctlplane
-      vif: true
-    - network: storage
-    - network: internal_api
-    - network: tenant
-    - network: external
-{% else %}
-- name: Compute{{ node_type }}
-  count: {{ machine_count[node_type]|int }}
-  hostname_format: compute{{ node_type}}-%index%
-  defaults:
-    profile: baremetal{{ node_type }}
-    network_config:
-      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
-    networks:
-    - network: ctlplane
-      vif: true
-    - network: storage
-    - network: internal_api
-    - network: tenant
-    - network: external
-{% endif %}
-{% endfor %}
-{% endif %}
-{% endif %}
+{%- if (failed_nodes_machine_type is defined) and (node_type in failed_nodes_machine_type|unique) %}
+{% set compute_count = compute_count - failed_nodes_machine_count[node_type]|int %}
+{% endif -%}
+
+{#- Case for whether ceph is enabled or not -#}
 
 {%- if ceph_enabled %}
+{% if (node_type|string() == controller_machine_type|string()) and (node_type|string() == ceph_machine_type|string()) %}
+{% set compute_count = compute_count - controller_count|int - ceph_node_count|int %}
+{% elif (node_type|string() == ceph_machine_type|string()) %}
+{% set compute_count = compute_count - ceph_node_count|int %}
+{% elif (node_type|string() == controller_machine_type|string()) %}
+{% set compute_count = compute_count - controller_count|int %}
+{% endif %}
+{% endif -%}
 
+{%- if ceph_enabled == false %}
+{% if (node_type|string() == controller_machine_type|string()) %}
+{% set compute_count = compute_count - controller_count|int %}
+{% endif %}
+{% endif -%}
+
+{%- if compute_count > 0 %}
+- name: Compute{{ node_type }}
+  count: {{ compute_count }}
+  hostname_format: compute{{ node_type }}-%index%
+  ansible_playbooks:
+    - playbook: /home/stack/overcloud-node-growvols.yml
+  defaults:
+    profile: baremetal{{ node_type }}
+    network_config:
+      template: /home/stack/virt/network/vlans/compute_{{ node_type }}.j2
+    networks:
+    - network: ctlplane
+      vif: true
+    - network: storage
+    - network: internal_api
+    - network: tenant
+    - network: external
+{% endif -%}
+{% endfor %}
+{% endif %}
+
+{% if ceph_enabled %}
 - name: CephStorage
   count: {{ ceph_node_count }}
   hostname_format: ceph-%index%
+  ansible_playbooks:
+    - playbook: /home/stack/overcloud-node-growvols.yml
   defaults:
     network_config:
       template: /home/stack/virt/network/vlans/ceph-storage.j2
@@ -140,4 +100,4 @@
       vif: true
     - network: storage
     - network: storage_mgmt
-{% endif -%}
+{% endif %}


### PR DESCRIPTION
It uses a custom overcloud-node-growvols playbook to extend the partitions.
This PR resolves https://github.com/redhat-performance/jetpack/issues/483