### PR TITLE
Run hammer in a rootless container

### DIFF
--- a/tasks/install_os.yml
+++ b/tasks/install_os.yml
@@ -45,7 +45,6 @@
       when: hypervisor_host == undercloud_hostname and osp_release|int >= 17
 
     - name: Build the images for hammercli
-      become: true
       shell: podman build --build-arg foreman_url={{ foreman_url }} -t hammercli .
       args:
         chdir: "{{ playbook_dir }}/hammer"
@@ -71,9 +70,8 @@
       when: lab_name == "alias"
 
     - name: update host to install new os
-      become: true
       shell: |
-        podman run hammercli {{ hammer_build_cmd }}
+        podman run --rm hammercli {{ hammer_build_cmd }}
 
     - name: set hypervisor host to PXE boot (Supermicro)
       shell: ipmitool -I lanplus -H mgmt-{{ hypervisor_host }} -U quads -P {{ chassis_password }} chassis bootdev pxe options=persistent


### PR DESCRIPTION
1) hammer doesn't need root privileges to update the host OS. 
2) run hammer container with --rm option as its no more required for the further run.
   Also this avoids containers ending up in an exited state on jumphost/ansible_control_node