### PR TITLE
Fix bridge mappings for br-ex for ML2/OVN non-DVR

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -133,6 +133,8 @@ interfaces:
 # - NeutronBridgeMappings=openshift:br-openshift,datacentre:br-ex
 # - NeutronNetworkVLANRanges=openshift:500:1000,datacentre:1:500
 # - ComputeParameters.NeutronBridgeMappings=openshift:br-openshift
+# For non-DVR OVN deployments, the comment on the line below should be removed to boot VMs on provider networks created on the datacentre network.
+# - ComputeParameters.NeutronBridgeMappings=datacentre:br-ex
 
 #resource_registry:
   # Enable root user password for all nodes


### PR DESCRIPTION
This PR adds an option in group_vars/all.yml to add neutron bridge mappings for datacentre:br-ex on compute nodes. This enables the datacentre network to be used for workloads that boot VMs on provider networks in OVN non-DVR deployments.

Resolves #492