### PR TITLE
Implements osd-spec for specifying storage_disks

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -279,6 +279,9 @@ osd_objectstore: bluestore
 #Note:By default storage_node_disks can be detected automatically
 #using introspection data
 #storage_node_disks: ['/dev/nvme0n1']
+#Note: By default the number of osds_per_device is set to 1. It can
+#be changed to another value through this parameter for OSP17.
+osds_per_device: 1
 #osd_pool_default_pg_num:
 #osd_pool_default_pgp_num:
 

--- a/overcloud.yml
+++ b/overcloud.yml
@@ -257,13 +257,25 @@
 
       - name: set facts for ceph deployment
         set_fact:
-          ceph_params: "--storage-backend ceph --storage-external no"
+          ceph_params: "{{ (osp_release|int >= 17) | ternary('--storage-backend ceph --storage-external no --ceph-osd-spec-file {{ osd_spec_file }}','--storage-backend ceph --storage-external no') }}"
         when: ceph_enabled
 
       - name: set deployment_timeout to 2400
         set_fact:
           deployment_timeout: 2400
         when: scale_compute_vms == true
+
+      - block:
+        - name: set fact for osd-spec.yml file
+          set_fact:
+            osd_spec_file: "{{ ansible_user_dir }}/osd-spec.yml"
+
+        - name: generate osd-spec.yml.j2
+          template:
+            src: osd-spec.yml.j2
+            dest: "{{ osd_spec_file }}"
+            force: yes
+        when: ceph_enabled and osp_release|int >= 17
 
       - name: run tripleo-overcloud deploy
         shell: |

--- a/post_introspect.yml
+++ b/post_introspect.yml
@@ -27,7 +27,6 @@
           with_items: "{{ total_nodes.stdout_lines | default([]) }}"
           when: composable_roles != true
 
-
         - name: introspection data for a nodes
           shell: |
             source ~/stackrc
@@ -53,12 +52,12 @@
             storage_node_disks: "{{ storage_node_disks|default([]) + item.stdout_lines }}"
           with_items: "{{ storage_disks_info_comp.results }}"
           when: composable_roles
-      when: storage_node_disks is not defined and ceph_enabled
+      when: storage_node_disks is not defined and ceph_enabled and osp_release|int < 17
 
     - name: show the storage_node_disks
       debug:
         msg: "{{ storage_node_disks|unique }}"
-      when: ceph_enabled
+      when: ceph_enabled and osp_release|int < 17
 
     - name: setting node capabilities (boot_mode bios)
       vars:
@@ -119,7 +118,7 @@
       - name: set fact for storage nodes
         set_fact:
           storage_node_disks: "{{ hostvars['undercloud']['storage_node_disks']|unique }}"
-        when: ceph_enabled and storage_node_disks is not defined
+        when: ceph_enabled and storage_node_disks is not defined and osp_release|int < 17
 
       - name: generate internal.yml.j2
         template:

--- a/templates/internal.yml.j2
+++ b/templates/internal.yml.j2
@@ -14,10 +14,12 @@ parameter_defaults:
   CephPoolDefaultPgNum: 32
   CephAnsiblePlaybookVerbosity: 1
   CephAnsibleDisksConfig:
+{% if osp_release|int < 17 %}
     devices:
 {% for disk in storage_node_disks[1:] %}
       - {{ disk }}
 {% endfor %}
+{% endif %}
 
 # the following two parameters are the defaults. Just included them here for info
     osd_scenario: {{ osd_scenario }}

--- a/templates/osd-spec.yml.j2
+++ b/templates/osd-spec.yml.j2
@@ -1,0 +1,10 @@
+data_devices:
+{%if storage_node_disks is defined %}
+  paths:
+{% for disk in storage_node_disks %}
+    - '{{disk}}'
+{% endfor %}
+{% else %}
+  all: true
+{% endif %}
+osds_per_device: {{ osds_per_device }}


### PR DESCRIPTION
Ceph 5 with OSP17 now makes use of a osd-spec file to specify devices on which OSDs will be created.
Also includes code optimisation for reducing the time to overcloud deployment.
This change implements osd-spec and resolves https://github.com/redhat-performance/jetpack/issues/489