### PR TITLE
Removes the changes for customising overcloud partitions.

### DIFF
--- a/overcloud.yml
+++ b/overcloud.yml
@@ -265,16 +265,6 @@
           deployment_timeout: 2400
         when: scale_compute_vms == true
 
-      - name: change the default values for overcloud-node-growvols
-        copy:
-          src: "overcloud-node-growvols.yml"
-          dest: "/home/stack/cli-overcloud-node-growvols.yml"
-        delegate_to: "{{ undercloud_hostname }}"
-        vars:
-          ansible_python_interpreter: "{{ python_interpreter }}"
-          ansible_user: "stack"
-        when: osp_release|int >= 17
-
       - name: run tripleo-overcloud deploy
         shell: |
             source .venv/bin/activate

--- a/templates/baremetal_deployment.yaml.j2
+++ b/templates/baremetal_deployment.yaml.j2
@@ -1,8 +1,6 @@
 - name: Controller
   count: {{ controller_count }}
   hostname_format: controller-%index%
-  ansible_playbooks:
-    - playbook: /home/stack/overcloud-node-growvols.yml
   defaults:
 {% if composable_roles %}
     profile: baremetal{{ controller_machine_type }}
@@ -24,8 +22,6 @@
 - name: Compute
   count: {{ compute_count }}
   hostname_format: compute-%index%
-  ansible_playbooks:
-    - playbook: /home/stack/overcloud-node-growvols.yml
   defaults:
     network_config:
       template: /home/stack/virt/network/vlans/compute.j2
@@ -69,8 +65,6 @@
 - name: Compute{{ node_type }}
   count: {{ compute_count }}
   hostname_format: compute{{ node_type }}-%index%
-  ansible_playbooks:
-    - playbook: /home/stack/overcloud-node-growvols.yml
   defaults:
     profile: baremetal{{ node_type }}
     network_config:
@@ -90,8 +84,6 @@
 - name: CephStorage
   count: {{ ceph_node_count }}
   hostname_format: ceph-%index%
-  ansible_playbooks:
-    - playbook: /home/stack/overcloud-node-growvols.yml
   defaults:
     network_config:
       template: /home/stack/virt/network/vlans/ceph-storage.j2


### PR DESCRIPTION
With overcloud-full image theses changes are no longer needed. 
Although the overcloud-node-growvols.yml file is left intact should we need to use it at any point in time later.