### PR TITLE
Minimise use of ovs bridges in OSP17

### DIFF
--- a/templates/ceph-storage.j2.j2
+++ b/templates/ceph-storage.j2.j2
@@ -14,22 +14,17 @@ network_config:
     default: true
 {% endraw %}
 
-- type: ovs_bridge
-  name: br-isolated
-  use_dhcp: false
-  members:
-  - type: interface
-    name: {{ storage_interface }}
-    primary: true
-  - type: vlan
-    vlan_id: {{ storage_network_vlan_id }}
-    {% raw -%}
-    addresses:
-    - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
+- type: vlan
+  device: {{ storage_interface }}
+  vlan_id: {{ storage_network_vlan_id }}
+  {% raw -%}
+  addresses:
+  - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
 {% endraw  %}
-  - type: vlan
-    vlan_id: {{ storage_mgmt_network_vlan_id }}
-    {% raw -%}
-    addresses:
-    - ip_netmask: {{ storage_mgmt_ip }}/{{ storage_mgmt_cidr }}
+- type: vlan
+  device: {{ storage_interface }}
+  vlan_id: {{ storage_mgmt_network_vlan_id }}
+  {% raw -%}
+  addresses:
+  - ip_netmask: {{ storage_mgmt_ip }}/{{ storage_mgmt_cidr }}
 {% endraw %}

--- a/templates/compute.j2.j2
+++ b/templates/compute.j2.j2
@@ -1,23 +1,18 @@
 ---
 network_config:
-- type: ovs_bridge
-  name: br-isolated
-  use_dhcp: false
-  members:
-  - type: interface
-    name: {{ isolated_interface }}
-    primary: true
-  - type: vlan
-    vlan_id: {{ internal_api_network_vlan_id }}
-    {% raw -%}
-    addresses:
-    - ip_netmask: {{ internal_api_ip }}/{{ internal_api_cidr }}
+- type: vlan
+  device: {{ isolated_interface }}
+  vlan_id: {{ internal_api_network_vlan_id }}
+  {% raw -%}
+  addresses:
+  - ip_netmask: {{ internal_api_ip }}/{{ internal_api_cidr }}
 {% endraw %}
-  - type: vlan
-    vlan_id: {{ storage_network_vlan_id }}
-    {% raw -%}
-    addresses:
-    - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
+- type: vlan
+  device: {{ isolated_interface }}
+  vlan_id: {{ storage_network_vlan_id }}
+  {% raw -%}
+  addresses:
+  - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
 {% endraw %}
 
 - type: interface

--- a/templates/controller.j2.j2
+++ b/templates/controller.j2.j2
@@ -1,29 +1,25 @@
 ---
 network_config:
-- type: ovs_bridge
-  name: br-isolated
-  use_dhcp: false
-  members:
-  - type: interface
-    name: {{ isolated_interface }}
-    primary: true
-  - type: vlan
-    vlan_id: {{ internal_api_network_vlan_id }}
-    {% raw -%}
-    addresses:
-    - ip_netmask: {{ internal_api_ip }}/{{ internal_api_cidr }}
+- type: vlan
+  device: {{ isolated_interface }}
+  vlan_id: {{ internal_api_network_vlan_id }}
+  {% raw -%}
+  addresses:
+  - ip_netmask: {{ internal_api_ip }}/{{ internal_api_cidr }}
 {% endraw %}
-  - type: vlan
-    vlan_id: {{ storage_network_vlan_id }}
-    {% raw -%}
-    addresses:
-    - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
+- type: vlan
+  device: {{ isolated_interface }}
+  vlan_id: {{ storage_network_vlan_id }}
+  {% raw -%}
+  addresses:
+  - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
 {% endraw %}
-  - type: vlan
-    vlan_id: {{ storage_mgmt_network_vlan_id }}
-    {% raw -%}
-    addresses:
-    - ip_netmask: {{ storage_mgmt_ip }}/{{ storage_mgmt_cidr }}
+- type: vlan
+  device: {{ isolated_interface }}
+  vlan_id: {{ storage_mgmt_network_vlan_id }}
+  {% raw -%}
+  addresses:
+  - ip_netmask: {{ storage_mgmt_ip }}/{{ storage_mgmt_cidr }}
 {% endraw %}
 
 {% if external_interface != ctlplane_interface %}


### PR DESCRIPTION
This PR moves internal-api, storage and storage-mgmt networks away from ovs bridges and onto the linux interface directly, to reduce load on ovs. This commit is for OSP 17. The changes for other OSP releases will be addressed in separate PRs. This PR has been tested on a 16 node environment with ceph enabled with composable roles for heterogeneous hardware.

Partially addresses #433