### PR TITLE
fix composable roles for osp < 17

### DIFF
--- a/templates/composable_roles_overcloud_deploy.sh.j2
+++ b/templates/composable_roles_overcloud_deploy.sh.j2
@@ -12,10 +12,11 @@ openstack overcloud deploy \
 {% endif %}
   --ntp-server {{ install.ntp.server }} \
   --stack {{ install.overcloud.stack }} \
+  -r /home/stack/roles_data.yaml \
+
 {% if install.version|default(undercloud_version)|openstack_release >= 17 %}
   --deployed-server \
   -e /usr/share/openstack-tripleo-heat-templates/environments/deployed-server-environment.yaml \
-  -r /home/stack/roles_data.yaml \
   -e /home/stack/templates/overcloud-vip-deployed.yaml \
   -e /home/stack/templates/overcloud-networks-deployed.yaml \
   -e /home/stack/templates/overcloud-baremetal-deployed.yaml \

--- a/templates/nodes_data.yml.j2
+++ b/templates/nodes_data.yml.j2
@@ -59,6 +59,10 @@ parameter_defaults:
   Compute{{ pci_node_type }}PCICount: {{ pci_node_count }}
 {% endif %}
 
+{% if controller_machine_type is defined %}
+  OvercloudControllerFlavor: baremetal{{ controller_machine_type }}
+{% endif %}
+
 {% for node_type in machine_types %}
   OvercloudCompute{{ node_type }}Flavor: baremetal{{ node_type }}
 {% endfor %}


### PR DESCRIPTION
- This PR defines flavor that needs to be used for controller
   when controller_machine_type is defined
- adjusts the overcloud deploy script