### PR TITLE
Fix the OSP17 Ceph Deploy

### DIFF
--- a/overcloud.yml
+++ b/overcloud.yml
@@ -255,16 +255,6 @@
             include_tasks: tasks/provisioning_baremetal_nodes.yml
         when: novaless_prov
 
-      - name: set facts for ceph deployment
-        set_fact:
-          ceph_params: "{{ (osp_release|int >= 17) | ternary('--storage-backend ceph --storage-external no --ceph-osd-spec-file {{ osd_spec_file }}','--storage-backend ceph --storage-external no') }}"
-        when: ceph_enabled
-
-      - name: set deployment_timeout to 2400
-        set_fact:
-          deployment_timeout: 2400
-        when: scale_compute_vms == true
-
       - block:
         - name: set fact for osd-spec.yml file
           set_fact:
@@ -276,6 +266,16 @@
             dest: "{{ osd_spec_file }}"
             force: yes
         when: ceph_enabled and osp_release|int >= 17
+
+      - name: set facts for ceph deployment
+        set_fact:
+          ceph_params: "{{ (osp_release|int >= 17) | ternary('--storage-backend ceph --storage-external no --ceph-osd-spec-file ' + osd_spec_file,'--storage-backend ceph --storage-external no') }}"
+        when: ceph_enabled
+
+      - name: set deployment_timeout to 2400
+        set_fact:
+          deployment_timeout: 2400
+        when: scale_compute_vms == true
 
       - name: run tripleo-overcloud deploy
         shell: |


### PR DESCRIPTION
Fixing the typo in ceph params to get the correct
osd_spec_file path during overcloud deploy
fixes #503