### PR TITLE
Ignore any failures while cleaning network ifaces

### DIFF
--- a/prepare_undercloud.yml
+++ b/prepare_undercloud.yml
@@ -21,6 +21,7 @@
       shell: |
         /root/clean-interfaces.sh --nuke
       changed_when: false
+      ignore_errors: true
 
     - name: Ensure SELinux is set to enforcing mode
       selinux:


### PR DESCRIPTION
Ignore any failures while cleaning network ifaces on undercloud, during undercloud prepare stage.
This PR resolves https://github.com/redhat-performance/jetpack/issues/510