### PR TITLE
Enables Manila for OSP17

### DIFF
--- a/composable.yml
+++ b/composable.yml
@@ -113,3 +113,14 @@
         openstack overcloud roles generate -o ~/roles_data.yaml --roles-path ~/roles {{ roles }}
       args:
         chdir: "/home/stack"
+
+    - block:
+      - name: create roles directory as required for infrared
+        file:
+          path: "~/virt/roles"
+          state: directory
+
+      - name: copy roles_data file to virt directory
+        shell: |
+          cp ~/roles_data.yaml ~/virt/roles/
+      when: ceph_enabled and osp_release|int >= 17

--- a/templates/baremetal_deployment.yaml.j2
+++ b/templates/baremetal_deployment.yaml.j2
@@ -1,4 +1,8 @@
+{% if manila_enabled %}
+- name: ControllerStorageNfs
+{% else %}
 - name: Controller
+{% endif %}
   count: {{ controller_count }}
   hostname_format: controller-%index%
   defaults:
@@ -14,6 +18,9 @@
       vif: true
     - network: storage
     - network: storage_mgmt
+{% if manila_enabled %}
+    - network: storage_nfs
+{% endif %}
     - network: internal_api
     - network: tenant
     - network: external

--- a/templates/controller.j2.j2
+++ b/templates/controller.j2.j2
@@ -1,5 +1,39 @@
 ---
 network_config:
+{% if manila_enabled %}
+- type: ovs_bridge
+  name: br-isolated
+  use_dhcp: false
+  members:
+  - type: interface
+    name: {{ isolated_interface }}
+    primary: true
+  - type: vlan
+    vlan_id: {{ internal_api_network_vlan_id }}
+    {% raw -%}
+    addresses:
+    - ip_netmask: {{ internal_api_ip }}/{{ internal_api_cidr }}
+{% endraw %}
+  - type: vlan
+    vlan_id: {{ storage_network_vlan_id }}
+    {% raw -%}
+    addresses:
+    - ip_netmask: {{ storage_ip }}/{{ storage_cidr }}
+{% endraw %}
+  - type: vlan
+    vlan_id: {{ storage_mgmt_network_vlan_id }}
+    {% raw -%}
+    addresses:
+    - ip_netmask: {{ storage_mgmt_ip }}/{{ storage_mgmt_cidr }}
+{% endraw %}
+  - type: vlan
+    vlan_id: {{ storage_nfs_network_vlan_id }}
+    {% raw -%}
+    addresses:
+    - ip_netmask: {{ storage_nfs_ip }}/{{ storage_nfs_cidr }}
+{% endraw %}
+
+{% else %}
 - type: vlan
   device: {{ isolated_interface }}
   vlan_id: {{ internal_api_network_vlan_id }}
@@ -21,6 +55,7 @@ network_config:
   addresses:
   - ip_netmask: {{ storage_mgmt_ip }}/{{ storage_mgmt_cidr }}
 {% endraw %}
+{% endif %}
 
 {% if external_interface != ctlplane_interface %}
 

--- a/templates/network-environment_v2.yaml.j2
+++ b/templates/network-environment_v2.yaml.j2
@@ -1,7 +1,11 @@
 # v2 config
 
 resource_registry:
+{% if manila_enabled %}
+    OS::TripleO::ControllerStorageNfs::Net::SoftwareConfig: OS::Heat::None
+{% else %}
     OS::TripleO::Controller::Net::SoftwareConfig: OS::Heat::None
+{% endif %}
 {% if composable_roles %}
 {% for node_type in machine_types %}
     OS::TripleO::Compute{{ node_type }}::Net::SoftwareConfig: OS::Heat::None
@@ -13,7 +17,11 @@ resource_registry:
     OS::TripleO::CephStorage::Net::SoftwareConfig: OS::Heat::None
 {% endif %}
 parameter_defaults:
+{% if manila_enabled %}
+    ControllerStorageNfsNetworkConfigTemplate: '/home/stack/virt/network/vlans/controller.j2'
+{% else %}
     ControllerNetworkConfigTemplate: '/home/stack/virt/network/vlans/controller.j2'
+{% endif %}
 {% if composable_roles %}
 {% for node_type in machine_types %}
     Compute{{ node_type }}NetworkConfigTemplate: '/home/stack/virt/network/vlans/compute_{{ node_type }}.j2'
@@ -24,8 +32,13 @@ parameter_defaults:
 {% if ceph_enabled %}
     CephStorageNetworkConfigTemplate: '/home/stack/virt/network/vlans/ceph-storage.j2'
 {% endif %}
+{% if manila_enabled %}
+    ControllerStorageNfsParameters:
+      NeutronBridgeMappings: "datacentre:br-ex,tenant:br-tenant,storage:br-isolated"
+{% else %}
     ControllerParameters:
-      NeutronBridgeMappings: "datacentre:br-ex,tenant:br-isolated"
+      NeutronBridgeMappings: "datacentre:br-ex,tenant:br-tenant"
+{% endif %}
 {% if composable_roles %}
 {% if dvr_enabled == false %}
 {% for node_type in machine_types %}
@@ -35,9 +48,12 @@ parameter_defaults:
 {% endif %}
 {% endif %}
     NeutronExternalNetworkBridge: ""
-    NeutronNetworkVLANRanges: " datacentre:300:900, tenant:200:2000"
-
 {% if dvr_enabled == true %}
     NeutronBridgeMappings: "datacentre:br-ex,tenant:br-tenant"
     NeutronEnableDVR: 'true'
+{% endif %}
+{% if manila_enabled %}
+    NeutronNetworkVLANRanges: "datacentre:300:900, tenant:200:2000, storage:305:305"
+{% else %}
+    NeutronNetworkVLANRanges: "datacentre:300:900, tenant:200:2000"
 {% endif %}

--- a/templates/network_data_v2.yaml.j2
+++ b/templates/network_data_v2.yaml.j2
@@ -58,3 +58,16 @@
       physical_network: external
       vlan: {{ external_network_vlan_id }}
 
+{% if manila_enabled %}
+- name: StorageNFS
+  name_lower: storage_nfs
+  subnets:
+    storage_nfs_subnet:
+      allocation_pools:
+      - end: {{ storage_nfs_allocation_pools_end }}
+        start: {{ storage_nfs_allocation_pools_start }}
+      ip_subnet: {{ storage_nfs_net_cidr }}
+      physical_network: storage_nfs
+      vlan: {{ storage_nfs_network_vlan_id }}
+  vip: true
+{% endif %}


### PR DESCRIPTION
Enables support for manila with nfsganesha for OSP17.
Also corrects tenant network mapping in network-env file. It was earlier pointing to br-isolated birdge whereas tenant network in the nic config file is attached to br-tenant bridge.
This PR resolves https://github.com/redhat-performance/jetpack/issues/508